### PR TITLE
chore: fix CI (fmt + clippy) and README style count

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Toggle segments with `claudebar config` or edit the `segments` list in `config.t
 ### Themes and styles
 
 - **Themes (16):** `tokyo-night` (default) · `ayu-mirage` · `catppuccin` · `cobalt2` · `everforest-dark` · `github-dark` · `gruvbox` · `kanagawa-wave` · `moonfly` · `night-owl` · `nord` · `one-dark` · `dracula` · `rose-pine` · `sonokai` · `solarized-dark`
-- **Styles (5):** `powerline` (default) · `plain` · `rounded` · `minimal` · `ascii`
+- **Styles (6):** `powerline` (default) · `plain` · `rounded` · `minimal` · `unicode` · `ascii`
 
 ### Config file
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -6,7 +6,9 @@ mod preview;
 mod sample;
 mod ui;
 
-use app::{build_list, detail_len, move_segment, App, Dir, Panel, RowItem, StatusKind, ThresholdField};
+use app::{
+    build_list, detail_len, move_segment, App, Dir, Panel, RowItem, StatusKind, ThresholdField,
+};
 use crossterm::event::{
     self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
     KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
@@ -370,48 +372,40 @@ fn handle_normal(app: &mut App, key: KeyEvent) {
         }
 
         // ── Segments (only in Segments section, right panel) ──────────────────
-        KeyCode::Char(' ') => {
-            if app.focused_panel == Panel::Right && app.menu_cursor == 0 {
-                app.toggle_cursor();
-            }
+        KeyCode::Char(' ') if app.focused_panel == Panel::Right && app.menu_cursor == 0 => {
+            app.toggle_cursor();
         }
-        KeyCode::Char('m') => {
-            if app.focused_panel == Panel::Right && app.menu_cursor == 0 {
-                // Build segment display order to find the kind at detail_cursor.
-                let display_order: Vec<crate::model::SegmentKind> = {
-                    let mut order = app.config.segments.clone();
-                    for &kind in &crate::model::SegmentKind::ALL {
-                        if !app.config.segments.contains(&kind) {
-                            order.push(kind);
-                        }
+        KeyCode::Char('m') if app.focused_panel == Panel::Right && app.menu_cursor == 0 => {
+            // Build segment display order to find the kind at detail_cursor.
+            let display_order: Vec<crate::model::SegmentKind> = {
+                let mut order = app.config.segments.clone();
+                for &kind in &crate::model::SegmentKind::ALL {
+                    if !app.config.segments.contains(&kind) {
+                        order.push(kind);
                     }
-                    order
-                };
-                match display_order.get(app.detail_cursor) {
-                    Some(&kind) if app.config.segments.contains(&kind) => {
-                        app.reorder_mode = true;
-                    }
-                    Some(_) => {
-                        app.status = Some((
-                            StatusKind::Warning,
-                            "Enable the segment first [Space]".into(),
-                        ));
-                    }
-                    None => {}
                 }
+                order
+            };
+            match display_order.get(app.detail_cursor) {
+                Some(&kind) if app.config.segments.contains(&kind) => {
+                    app.reorder_mode = true;
+                }
+                Some(_) => {
+                    app.status = Some((
+                        StatusKind::Warning,
+                        "Enable the segment first [Space]".into(),
+                    ));
+                }
+                None => {}
             }
         }
 
         // ── Thresholds (large nudge, only in Thresholds section, right panel) ─
-        KeyCode::Char('H') => {
-            if app.focused_panel == Panel::Right && app.menu_cursor == 3 {
-                app.nudge_threshold(threshold_field_at(app.detail_cursor), -5);
-            }
+        KeyCode::Char('H') if app.focused_panel == Panel::Right && app.menu_cursor == 3 => {
+            app.nudge_threshold(threshold_field_at(app.detail_cursor), -5);
         }
-        KeyCode::Char('L') => {
-            if app.focused_panel == Panel::Right && app.menu_cursor == 3 {
-                app.nudge_threshold(threshold_field_at(app.detail_cursor), 5);
-            }
+        KeyCode::Char('L') if app.focused_panel == Panel::Right && app.menu_cursor == 3 => {
+            app.nudge_threshold(threshold_field_at(app.detail_cursor), 5);
         }
 
         // ── Global ────────────────────────────────────────────────────────────
@@ -470,8 +464,7 @@ fn handle_mouse(app: &mut App, event: MouseEvent) {
                 let inner_row = row.saturating_sub(left.y + 1) as usize;
                 if inner_row < 4 {
                     app.menu_cursor = inner_row;
-                    app.detail_cursor =
-                        app.detail_cursor.min(detail_len(app).saturating_sub(1));
+                    app.detail_cursor = app.detail_cursor.min(detail_len(app).saturating_sub(1));
                 }
             } else if contains(right, col, row) {
                 app.focused_panel = Panel::Right;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -37,7 +37,11 @@ fn panel_block(title: &str, active: bool) -> Block<'_> {
     } else {
         Block::bordered()
             .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(CHROME_HEADER).add_modifier(Modifier::DIM))
+            .border_style(
+                Style::default()
+                    .fg(CHROME_HEADER)
+                    .add_modifier(Modifier::DIM),
+            )
             .title(Span::styled(
                 format!(" {title} "),
                 Style::default()
@@ -593,9 +597,7 @@ fn draw_hint(f: &mut Frame, app: &App, area: Rect) {
             ("[?]", " help  "),
             ("[q]", " quit"),
         ])
-    } else if app.focused_panel == Panel::Right
-        && (app.menu_cursor == 1 || app.menu_cursor == 2)
-    {
+    } else if app.focused_panel == Panel::Right && (app.menu_cursor == 1 || app.menu_cursor == 2) {
         hint_line(&[
             ("[↑↓]", " browse  "),
             ("[s]", " save  "),


### PR DESCRIPTION
Pre-public cleanup.

## Changes
- **CI fix (rust workflow was red on main):** `cargo fmt` the two-panel TUI layout + collapse 4 clippy `collapsible_match` warnings in `src/tui/{mod,ui}.rs`.
- **README:** styles count 5 → 6 (`unicode` was missing from the list).

## Verification
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo build --release --no-default-features` ✅
- `bash -n install.sh statusline-command.sh` ✅

Note: local `cargo test` hits a broken local `.gsd` symlink during insta glob walk — gitignored, not present in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)