### PR TITLE
fix(deps): update rust crate thiserror to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.9"
 clap = { version = "4", features = ["derive"] }
-thiserror = "1"
+thiserror = "2"
 
 # TUI-only (feature-gated, never linked on the render hot path)
 ratatui = { version = "0.30", optional = true }


### PR DESCRIPTION
Replaces #11 (Renovate PR had Cargo.lock conflicts after ratatui/ansi-to-tui upgrade in #14).

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — all pass  
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)