### PR TITLE
fix: unify segment spacing — remove redundant padding in Clock, Cost, Burn

### DIFF
--- a/src/render/float.rs
+++ b/src/render/float.rs
@@ -286,8 +286,8 @@ mod tests {
 
     #[test]
     fn uses_custom_separator() {
-        // model = "m" (icons off → bare name); cost = " 2.50 " (leading/trailing
-        // space around the formatted value). Joined by "::".
+        // model = "m" (icons off → bare name); cost = "2.50" (no extra
+        // padding — spacing is the separator's job). Joined by "::".
         let input = InputData {
             model: ModelData {
                 display_name: Some("m".into()),
@@ -301,7 +301,7 @@ mod tests {
         let mut cfg = float_cfg("model cost");
         cfg.thresholds.float_sep = "::".into();
         let line = render_float(&input, &cfg, 0, None);
-        assert_eq!(line, "m:: 2.50 ");
+        assert_eq!(line, "m::2.50");
     }
 
     #[test]

--- a/src/segment/burn.rs
+++ b/src/segment/burn.rs
@@ -238,13 +238,13 @@ fn render_burn(ctx: &RenderCtx, out: &mut SegmentWriter, burn: &BurnEstimate) {
         BurnState::Warming => {
             out.colored_with(burn.color, |w| {
                 w.icon(glyph);
-                w.raw(" … ");
+                w.raw("…");
             });
         }
         BurnState::Idle => {
             out.colored_with(burn.color, |w| {
                 w.icon(glyph);
-                w.raw(" ✓ ");
+                w.raw("✓");
             });
         }
         BurnState::Active => {
@@ -252,18 +252,14 @@ fn render_burn(ctx: &RenderCtx, out: &mut SegmentWriter, burn: &BurnEstimate) {
                 // 7d stateless: just show the label.
                 out.colored_with(burn.color, |w| {
                     w.icon(glyph);
-                    w.raw(" ");
                     w.raw(burn.label);
-                    w.raw(" ");
                 });
             } else {
                 out.colored_with(burn.color, |w| {
                     w.icon(glyph);
-                    w.raw(" ");
                     w.raw(burn.label);
                     w.raw(" ⇢ ");
                     w.raw(&burn.eta);
-                    w.raw(" ");
                 });
             }
         }

--- a/src/segment/clock.rs
+++ b/src/segment/clock.rs
@@ -197,9 +197,7 @@ impl Segment for Clock {
 
         out.colored_with(ctx.theme.clock, |w| {
             w.icon(ctx.style.glyphs.time);
-            w.raw(" ");
             w.raw(&time_str);
-            w.raw(" ");
         });
         true
     }

--- a/src/segment/cost.rs
+++ b/src/segment/cost.rs
@@ -18,9 +18,7 @@ impl Segment for Cost {
 
         out.colored_with(ctx.theme.cost, |w| {
             w.icon(ctx.style.glyphs.cost);
-            w.raw(" ");
             w.raw_fmt(format_args!("{:.*}", decimals, cost));
-            w.raw(" ");
         });
         true
     }


### PR DESCRIPTION
## Problem

Three segments (Clock, Cost, Burn) had visibly wider gaps than the other five. The eye reads uneven spacing as a rhythm disruption — a violation of the Gestalt law of similarity.

**Root cause:** `w.icon()` already appends a trailing space after the glyph. The manual `w.raw(" ")` calls inside `colored_with` closures created double-spacing. Other segments (Directory, Git, Model, Context, RateLimits) never did this — they relied solely on `icon()` for their leading padding.

## Fix

Removes redundant `w.raw(" ")` calls in Clock, Cost, and Burn:

| Segment | Before | After |
|---------|--------|-------|
| Clock | `<icon>  15:18 ` | `<icon> 15:18` |
| Cost | `<icon>  $1.23 ` | `<icon> $1.23` |
| Burn | `<icon>  5h ⇢ 42m ` | `<icon> 5h ⇢ 42m` |

Burn status indicators (" … ", " ✓ ") tightened to "…" / "✓" — `icon()` provides the leading space.

## Design rationale

- `icon()` already owns the trailing-space convention — segments must not duplicate it
- The inter-segment separator (`" "` + glyph + `" "`) provides consistent gaps
- All 8 default segments now share the same visual rhythm

**Gap uniformity before/after** (visible spaces between segment contents, excluding glyphs):

| Transition | Before | After |
|------------|--------|-------|
| Directory → Git | 2 | 2 |
| Git → Model | 2 | 2 |
| Model → Context | 2 | 2 |
| Context → RateLimits | 2 | 2 |
| **RateLimits → Cost** | **3** | **2** |
| **Cost → Burn** | **4** | **2** |
| **Burn → Clock** | **4** | **2** |

Gap dispersion: `[2,2,2,2,3,4,4]` (range 2) → `[2,2,2,2,2,2,2]` (range 0).

## Tested

- 234/234 tests pass
- Visual smoke test confirms uniform spacing with `fixtures/typical.json`