### PR TITLE
fix: unify segment spacing — remove redundant padding in Clock, Cost, Burn

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ macOS and Linux, x86_64 / aarch64. One command — the installer downloads the b
 curl -fsSL https://raw.githubusercontent.com/micschr0/claudebar/main/install.sh | bash
 ```
 
+Prefer to review the script before running it? Download, inspect, then execute:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/micschr0/claudebar/main/install.sh -o install.sh
+less install.sh   # or your editor of choice
+bash install.sh
+```
+
 Or via Homebrew, then let `setup` do the wiring:
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -4,30 +4,15 @@
 set -euo pipefail
 
 BIN_DEST="$HOME/.claude/claudebar"
-
-# Directory this script lives in, when run from a checkout (empty under `curl | bash`).
-SRC_DIR=""
-case "$0" in
-  */*) SRC_DIR=$(cd "$(dirname "$0")" 2>/dev/null && pwd || true) ;;
-  *)   [ -f "${PWD}/Cargo.toml" ] && SRC_DIR="$PWD" ;;
-esac
-
-TMPDIR_WORK=$(mktemp -d)
-trap 'rm -rf "$TMPDIR_WORK"' EXIT
+RELEASE_API="https://api.github.com/repos/micschr0/claudebar/releases/latest"
 
 red()   { printf '\033[31m%s\033[0m\n' "$*"; }
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
 bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
 
-# curl_https — curl wrapper pinned to HTTPS + TLS 1.2+ so a redirect or
-# MITM can't downgrade the connection to plaintext or an older TLS version.
+# Pinned to HTTPS + TLS 1.2+ so a redirect or MITM can't downgrade the connection.
 curl_https() { curl --proto '=https' --tlsv1.2 -fsSL "$@"; }
 
-# ── Preflight ──────────────────────────────────────────────────────────────────
-# git is a soft runtime dependency (the git segment). curl and jq are needed for
-# the prebuilt binary download path (fetch_latest_tag, download_prebuilt).
-bold "Checking dependencies..."
-echo ""
 install_hint() {
   case "$1" in
     curl) echo "  macOS:  brew install curl" ;;
@@ -37,56 +22,34 @@ install_hint() {
   echo "  Linux:  sudo apt install $1   # or: sudo dnf install $1"
 }
 
-if command -v git >/dev/null 2>&1; then
-  printf '  %-6s %s\n' "git" "$(command -v git)"
-else
-  red "  git    not found — the git segment stays hidden until you install it"
-  install_hint git
-fi
-
-if command -v curl >/dev/null 2>&1; then
-  printf '  %-6s %s\n' "curl" "$(command -v curl)"
-else
-  red "  curl   not found — prebuilt binary download will fail"
-  install_hint curl
-fi
-
-if command -v jq >/dev/null 2>&1; then
-  printf '  %-6s %s\n' "jq" "$(command -v jq)"
-else
-  red "  jq     not found — prebuilt binary download will fail"
-  install_hint jq
-fi
-echo ""
-
-mkdir -p "$HOME/.claude"
-
-# ── Helper functions ───────────────────────────────────────────────────────────
-
-# check_nerd_font — return 0 if a Nerd Font is installed, 1 otherwise.
-# Uses fc-list when available; falls back to scanning common font directories.
-check_nerd_font() {
-    # Try fc-list first — fastest and most accurate.
-    if command -v fc-list >/dev/null 2>&1; then
-        if fc-list :family 2>/dev/null | grep -qi 'nerd'; then
-            return 0
-        fi
-    fi
-
-    # Fallback: scan common font directories (non-recursive, matching main.rs).
-    local dir
-    for dir in "/usr/share/fonts" "/usr/local/share/fonts" "$HOME/.local/share/fonts" "$HOME/.fonts"; do
-        if [ -d "$dir" ] && find "$dir" -maxdepth 1 \( -name '*Nerd*' -o -name '*nerd*' \) \( -name '*.ttf' -o -name '*.otf' \) -print -quit 2>/dev/null | grep -q .; then
-            return 0
-        fi
-    done
-
-    return 1
+report_dependency() {
+  local name="$1" consequence="$2"
+  if command -v "$name" >/dev/null 2>&1; then
+    printf '  %-6s %s\n' "$name" "$(command -v "$name")"
+  else
+    printf '\033[31m  %-6s not found — %s\033[0m\n' "$name" "$consequence"
+    install_hint "$name"
+  fi
 }
-# detect_target — print the Rust target triple for the current OS/arch, or
-# empty string if no prebuilt binary is available for this platform.
-# CLAUDEBAR_TARGET overrides detection (used by verify-install.yml to exercise
-# the aarch64 asset from an x86_64 runner without needing emulation).
+
+check_dependencies() {
+  bold "Checking dependencies..."
+  echo ""
+  report_dependency git  "the git segment stays hidden until you install it"
+  report_dependency curl "prebuilt binary download will fail"
+  report_dependency jq   "prebuilt binary download will fail"
+  echo ""
+}
+
+detect_source_dir() {
+  case "$0" in
+    */*) cd "$(dirname "$0")" 2>/dev/null && pwd || true ;;
+    *)   [ -f "${PWD}/Cargo.toml" ] && printf '%s' "$PWD" || true ;;
+  esac
+}
+
+# Prints the Rust target triple for this OS/arch, or nothing if unsupported.
+# CLAUDEBAR_TARGET overrides detection (used by verify-install.yml).
 detect_target() {
   if [ -n "${CLAUDEBAR_TARGET:-}" ]; then
     printf '%s' "$CLAUDEBAR_TARGET"
@@ -98,59 +61,46 @@ detect_target() {
   case "$arch" in
     arm64|aarch64) arch="aarch64" ;;
     x86_64)        arch="x86_64"  ;;
-    *) printf ''; return ;;
+    *) return ;;
   esac
   case "$os" in
     Linux)  printf '%s-unknown-linux-musl' "$arch" ;;
     Darwin) printf '%s-apple-darwin'       "$arch" ;;
-    *)      printf '' ;;
   esac
 }
 
-# fetch_latest_release — print the full "latest" release JSON, or empty
-# string if no release exists yet. Cached in LATEST_RELEASE_JSON so callers
-# that need both the tag and its asset list only hit the API once.
 LATEST_RELEASE_JSON=""
 fetch_latest_release() {
   if [ -z "$LATEST_RELEASE_JSON" ]; then
-    LATEST_RELEASE_JSON=$(curl_https "https://api.github.com/repos/micschr0/claudebar/releases/latest")
+    LATEST_RELEASE_JSON=$(curl_https "$RELEASE_API")
   fi
   printf '%s' "$LATEST_RELEASE_JSON"
 }
 
-# fetch_latest_tag — print the latest GitHub release tag, or empty string if
-# no release exists yet.
-fetch_latest_tag() {
-  fetch_latest_release | jq -r '.tag_name // empty'
+release_tag() {
+  printf '%s' "$1" | jq -r '.tag_name // empty'
 }
 
-# find_asset_url <json> <regex> — print the browser_download_url of the first
-# release asset whose name matches <regex> (extended regex, jq `test`), or
-# empty string if none match. Resolving by pattern instead of hand-building
-# the filename keeps this in sync with whatever naming scheme the release
-# workflow (cargo-dist) actually uses.
+# Resolves asset names by pattern instead of hand-building filenames — the
+# naming scheme is owned by the release workflow (cargo-dist) and has changed before.
 find_asset_url() {
   local json="$1" regex="$2"
   printf '%s' "$json" | jq -r --arg re "$regex" \
     '[.assets[] | select(.name | test($re))][0].browser_download_url // empty'
 }
 
-# require_github_host <url> — abort if <url> does not point at github.com.
-# The GitHub API response is otherwise trusted blindly for download URLs; this
-# guards against a compromised/spoofed API response redirecting the install
-# to an arbitrary host.
+# Download URLs come from the GitHub API response, which is otherwise trusted
+# blindly — reject anything not hosted on github.com.
 require_github_host() {
   case "$1" in
-    https://github.com/*) ;;
+    https://github.com/*) return 0 ;;
     *)
       red "Refusing to download from untrusted host: $1"
-      exit 1
+      return 1
       ;;
   esac
 }
 
-# sha256_of <file> — print the SHA256 hex digest of <file>.
-# Uses sha256sum (Linux) or shasum -a 256 (macOS).
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$1" | awk '{print $1}'
@@ -159,10 +109,7 @@ sha256_of() {
   fi
 }
 
-# verify_checksum <file> <archive_name> <sums_file> — verify <file> against
-# the sha256.sum entry for <archive_name>. Returns 1 on mismatch (fatal).
-# Matches both sha256sum output formats: text mode ("hash  name") and
-# binary mode ("hash *name") — cargo-dist emits the latter.
+# Accepts both sha256sum output formats: "hash  name" and "hash *name".
 verify_checksum() {
   local file="$1" archive_name="$2" sums_file="$3"
   local expected actual
@@ -181,27 +128,40 @@ verify_checksum() {
     return 1
   fi
   green "SHA256 verified"
-  return 0
 }
 
-# download_prebuilt <target> — download the prebuilt binary for <target>,
-# verify its SHA256 checksum, extract it, and install to BIN_DEST.
-# Returns 0 on success, 1 on any recoverable failure (falls through to Tier 2).
-# Checksum mismatch is fatal and does NOT trigger a fallback.
-download_prebuilt() {
-  local target="$1"
+archive_has_unsafe_paths() {
+  tar -tf "$1" | grep -qE '(^|/)\.\.(/|$)|^/'
+}
+
+extract_archive() {
+  local archive="$1" dest="$2"
+  if archive_has_unsafe_paths "$archive"; then
+    red "Archive contains unsafe paths (.. or absolute) — aborting"
+    return 1
+  fi
+  tar --no-same-owner -xf "$archive" -C "$dest"
+}
+
+install_binary() {
+  local src="$1"
+  mv "$src" "$BIN_DEST"
+  chmod +x "$BIN_DEST"
+}
+
+# Returns 0 on success, 1 on any recoverable failure (falls through to the
+# cargo build tier). Checksum mismatch or an untrusted host is fatal.
+install_prebuilt() {
+  local target="$1" workdir="$2"
   local release tag archive url sums_url
+
   release=$(fetch_latest_release)
-  tag=$(printf '%s' "$release" | jq -r '.tag_name // empty')
+  tag=$(release_tag "$release")
   if [ -z "$tag" ]; then
     bold "No prebuilt release found — falling back to cargo build"
     return 1
   fi
 
-  # Resolve the actual asset names from the release instead of hand-building
-  # them — the naming scheme is owned by the release workflow (cargo-dist),
-  # not by this script, and has changed before (tag embedded in the archive
-  # name, sums file renamed from sha256.sum to SHA256SUMS.txt).
   url=$(find_asset_url "$release" "^claudebar-${target}\\.tar\\.gz$")
   sums_url=$(find_asset_url "$release" '^(SHA256SUMS\.txt|sha256\.sum)$')
   if [ -z "$url" ]; then
@@ -214,49 +174,54 @@ download_prebuilt() {
     bold "Falling back to cargo build..."
     return 1
   fi
-  require_github_host "$url"
-  require_github_host "$sums_url"
+  require_github_host "$url" || exit 1
+  require_github_host "$sums_url" || exit 1
   archive="${url##*/}"
 
   bold "Downloading ${archive}..."
-  if ! curl_https "$url" -o "${TMPDIR_WORK}/${archive}"; then
+  if ! curl_https "$url" -o "${workdir}/${archive}"; then
     red "Download failed — binary may not exist for this release yet"
     bold "Falling back to cargo build..."
     return 1
   fi
+  curl_https "$sums_url" -o "${workdir}/sha256.sum"
+  verify_checksum "${workdir}/${archive}" "$archive" "${workdir}/sha256.sum" || exit 1
 
-  curl_https "$sums_url" -o "${TMPDIR_WORK}/sha256.sum"
-  if ! verify_checksum "${TMPDIR_WORK}/${archive}" "$archive" "${TMPDIR_WORK}/sha256.sum"; then
-    exit 1
-  fi
-
-  # Defense-in-depth: reject archives containing path-traversal or absolute
-  # entries before extracting, even though the checksum above already ties
-  # the archive to the signed release.
-  if tar -tf "${TMPDIR_WORK}/${archive}" | grep -qE '(^|/)\.\.(/|$)|^/'; then
-    red "Archive ${archive} contains unsafe paths (.. or absolute) — aborting"
-    exit 1
-  fi
-
-  tar --no-same-owner -xf "${TMPDIR_WORK}/${archive}" -C "${TMPDIR_WORK}/"
-  mv "${TMPDIR_WORK}/claudebar" "$BIN_DEST"
-  chmod +x "$BIN_DEST"
+  extract_archive "${workdir}/${archive}" "$workdir" || exit 1
+  install_binary "${workdir}/claudebar"
   green "claudebar ${tag} installed to ${BIN_DEST}"
-  return 0
 }
 
-# link_onto_path — make `claudebar` runnable from any shell. The binary lives at
-# $BIN_DEST (~/.claude/claudebar), which is not on PATH, so `claudebar
-# config|doctor|edit|list` would be "command not found". The statusLine uses the
-# absolute $BIN_DEST path and is unaffected either way. Skips entirely if
-# `claudebar` already resolves (e.g. a Homebrew install) so we never shadow it.
+install_from_source() {
+  local src_dir="$1"
+  if [ -z "$src_dir" ]; then
+    bold "No local checkout detected — cargo build requires source."
+    return 1
+  fi
+  if [ ! -f "${src_dir}/Cargo.toml" ]; then
+    bold "No Cargo.toml in ${src_dir} — cannot build from source."
+    return 1
+  fi
+  if ! command -v cargo >/dev/null 2>&1; then
+    bold "cargo not found."
+    return 1
+  fi
+  bold "Building from source with cargo..."
+  if ! cargo build --release --manifest-path "${src_dir}/Cargo.toml"; then
+    red "cargo build failed."
+    return 1
+  fi
+  install -m 0755 "${src_dir}/target/release/claudebar" "$BIN_DEST"
+  green "claudebar built and installed to ${BIN_DEST}"
+}
+
+# Makes `claudebar` runnable from any shell. Skips if it already resolves
+# (e.g. a Homebrew install) so we never shadow it.
 link_onto_path() {
   if command -v claudebar >/dev/null 2>&1; then
     return 0
   fi
 
-  # Prefer a directory already on PATH and writable — then the command works
-  # immediately, no shell-rc edit needed.
   local dir target=""
   for dir in "/usr/local/bin" "$HOME/.local/bin" "$HOME/bin"; do
     case ":$PATH:" in *":$dir:"*) ;; *) continue ;; esac
@@ -272,7 +237,6 @@ link_onto_path() {
     return 0
   fi
 
-  # Nothing writable on PATH — link into ~/.local/bin and say how to reach it.
   target="$HOME/.local/bin"
   mkdir -p "$target"
   ln -sf "$BIN_DEST" "$target/claudebar"
@@ -281,61 +245,76 @@ link_onto_path() {
   echo "  Add it:  echo 'export PATH=\"${target}:\$PATH\"' >> ~/.zshrc   # or ~/.bashrc, then restart your shell"
 }
 
-# ── Install ────────────────────────────────────────────────────────────────────
-COMMAND_VALUE=""
-
-# Tier 1: Prebuilt binary
-TARGET=$(detect_target)
-if [ -n "$TARGET" ]; then
-  if download_prebuilt "$TARGET"; then
-    COMMAND_VALUE="${BIN_DEST} render"
-  fi
-else
-  bold "No prebuilt binary for $(uname -s)/$(uname -m) — skipping download"
-fi
-
-# Tier 2: Cargo build (local checkout only — not available under curl | bash)
-if [ -z "$COMMAND_VALUE" ]; then
-  if [ -n "$SRC_DIR" ] && [ -f "${SRC_DIR}/Cargo.toml" ] && command -v cargo >/dev/null 2>&1; then
-    bold "Building from source with cargo..."
-    if cargo build --release --manifest-path "${SRC_DIR}/Cargo.toml"; then
-      install -m 0755 "${SRC_DIR}/target/release/claudebar" "$BIN_DEST"
-      COMMAND_VALUE="${BIN_DEST} render"
-      green "claudebar built and installed to ${BIN_DEST}"
-    else
-      red "cargo build failed."
+check_nerd_font() {
+  if command -v fc-list >/dev/null 2>&1; then
+    if fc-list :family 2>/dev/null | grep -qi 'nerd'; then
+      return 0
     fi
-  elif [ -z "$SRC_DIR" ]; then
-    bold "No local checkout detected — cargo build requires source."
-  else
-    bold "cargo not found."
   fi
-fi
+  local dir
+  for dir in "/usr/share/fonts" "/usr/local/share/fonts" "$HOME/.local/share/fonts" "$HOME/.fonts"; do
+    if [ -d "$dir" ] && find "$dir" -maxdepth 1 \( -name '*Nerd*' -o -name '*nerd*' \) \( -name '*.ttf' -o -name '*.otf' \) -print -quit 2>/dev/null | grep -q .; then
+      return 0
+    fi
+  done
+  return 1
+}
 
-if [ -z "$COMMAND_VALUE" ]; then
-  red "No installation method succeeded (no prebuilt binary for this platform and no local cargo build available)."
-  echo "Install Rust (https://rustup.rs) and re-run from a checkout, or wait for a prebuilt release for your platform."
-  exit 1
-fi
-
-# ── Configure statusLine ─────────────────────────────────────────────────────────
-"$BIN_DEST" setup --yes --binary-path "$BIN_DEST"
-link_onto_path
-
-# ── Done ───────────────────────────────────────────────────────────────────────
-echo ""
-bold "Installation complete."
-echo "Restart Claude Code — claudebar appears on the next turn."
-echo ""
-# Nerd Font check (non-blocking — always runs after install)
-if check_nerd_font; then
+report_nerd_font() {
+  if check_nerd_font; then
     green "✓ Nerd Font detected"
-else
+  else
     red "⚠ No Nerd Font detected. The statusline uses powerline glyphs — install a Nerd Font for best results: https://www.nerdfonts.com"
     if [ "$(uname -s)" = "Darwin" ]; then
-        echo "  macOS:  brew install --cask font-hack-nerd-font"
+      echo "  macOS:  brew install --cask font-hack-nerd-font"
     fi
     echo "Tip: run 'claudebar config' and choose the 'ascii' style for glyph-free rendering."
+  fi
+}
+
+main() {
+  local workdir src_dir target installed=1
+
+  check_dependencies
+  mkdir -p "$HOME/.claude"
+
+  workdir=$(mktemp -d)
+  trap 'rm -rf "$workdir"' EXIT
+  src_dir=$(detect_source_dir)
+
+  target=$(detect_target)
+  if [ -n "$target" ]; then
+    if install_prebuilt "$target" "$workdir"; then
+      installed=0
+    fi
+  else
+    bold "No prebuilt binary for $(uname -s)/$(uname -m) — skipping download"
+  fi
+
+  if [ "$installed" -ne 0 ]; then
+    if install_from_source "$src_dir"; then
+      installed=0
+    fi
+  fi
+
+  if [ "$installed" -ne 0 ]; then
+    red "No installation method succeeded (no prebuilt binary for this platform and no local cargo build available)."
+    echo "Install Rust (https://rustup.rs) and re-run from a checkout, or wait for a prebuilt release for your platform."
+    exit 1
+  fi
+
+  "$BIN_DEST" setup --yes --binary-path "$BIN_DEST"
+  link_onto_path
+
+  echo ""
+  bold "Installation complete."
+  echo "Restart Claude Code — claudebar appears on the next turn."
+  echo ""
+  report_nerd_font
+  echo ""
+  echo "Troubleshooting: run 'claudebar doctor', or visit https://micschr0.github.io/claudebar/"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi
-echo ""
-echo "Troubleshooting: run 'claudebar doctor', or visit https://micschr0.github.io/claudebar/"

--- a/install.sh
+++ b/install.sh
@@ -3,10 +3,7 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/micschr0/claudebar/main/install.sh | bash
 set -euo pipefail
 
-REPO="https://raw.githubusercontent.com/micschr0/claudebar/main"
-SCRIPT_DEST="$HOME/.claude/statusline-command.sh"
 BIN_DEST="$HOME/.claude/claudebar"
-SETTINGS="${SETTINGS:-$HOME/.claude/settings.json}"
 
 # Directory this script lives in, when run from a checkout (empty under `curl | bash`).
 SRC_DIR=""
@@ -22,12 +19,13 @@ red()   { printf '\033[31m%s\033[0m\n' "$*"; }
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
 bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
 
+# curl_https — curl wrapper pinned to HTTPS + TLS 1.2+ so a redirect or
+# MITM can't downgrade the connection to plaintext or an older TLS version.
+curl_https() { curl --proto '=https' --tlsv1.2 -fsSL "$@"; }
+
 # ── Preflight ──────────────────────────────────────────────────────────────────
 # git is a soft runtime dependency (the git segment). curl and jq are needed for
-# the prebuilt binary download path (fetch_latest_tag, download_prebuilt); jq is
-# separately needed for the settings.json merge, but only when falling back to
-# the bash script (no compiled claudebar binary to invoke `setup` with).
-# The happy path (prebuilt binary) needs curl + jq. Nothing else is required.
+# the prebuilt binary download path (fetch_latest_tag, download_prebuilt).
 bold "Checking dependencies..."
 echo ""
 install_hint() {
@@ -115,7 +113,7 @@ detect_target() {
 LATEST_RELEASE_JSON=""
 fetch_latest_release() {
   if [ -z "$LATEST_RELEASE_JSON" ]; then
-    LATEST_RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/micschr0/claudebar/releases/latest")
+    LATEST_RELEASE_JSON=$(curl_https "https://api.github.com/repos/micschr0/claudebar/releases/latest")
   fi
   printf '%s' "$LATEST_RELEASE_JSON"
 }
@@ -135,6 +133,20 @@ find_asset_url() {
   local json="$1" regex="$2"
   printf '%s' "$json" | jq -r --arg re "$regex" \
     '[.assets[] | select(.name | test($re))][0].browser_download_url // empty'
+}
+
+# require_github_host <url> — abort if <url> does not point at github.com.
+# The GitHub API response is otherwise trusted blindly for download URLs; this
+# guards against a compromised/spoofed API response redirecting the install
+# to an arbitrary host.
+require_github_host() {
+  case "$1" in
+    https://github.com/*) ;;
+    *)
+      red "Refusing to download from untrusted host: $1"
+      exit 1
+      ;;
+  esac
 }
 
 # sha256_of <file> — print the SHA256 hex digest of <file>.
@@ -174,7 +186,7 @@ verify_checksum() {
 
 # download_prebuilt <target> — download the prebuilt binary for <target>,
 # verify its SHA256 checksum, extract it, and install to BIN_DEST.
-# Returns 0 on success, 1 on any recoverable failure (triggers Tier 2).
+# Returns 0 on success, 1 on any recoverable failure (falls through to Tier 2).
 # Checksum mismatch is fatal and does NOT trigger a fallback.
 download_prebuilt() {
   local target="$1"
@@ -202,21 +214,31 @@ download_prebuilt() {
     bold "Falling back to cargo build..."
     return 1
   fi
+  require_github_host "$url"
+  require_github_host "$sums_url"
   archive="${url##*/}"
 
   bold "Downloading ${archive}..."
-  if ! curl -fsSL "$url" -o "${TMPDIR_WORK}/${archive}"; then
+  if ! curl_https "$url" -o "${TMPDIR_WORK}/${archive}"; then
     red "Download failed — binary may not exist for this release yet"
     bold "Falling back to cargo build..."
     return 1
   fi
 
-  curl -fsSL "$sums_url" -o "${TMPDIR_WORK}/sha256.sum"
+  curl_https "$sums_url" -o "${TMPDIR_WORK}/sha256.sum"
   if ! verify_checksum "${TMPDIR_WORK}/${archive}" "$archive" "${TMPDIR_WORK}/sha256.sum"; then
     exit 1
   fi
 
-  tar -xf "${TMPDIR_WORK}/${archive}" -C "${TMPDIR_WORK}/"
+  # Defense-in-depth: reject archives containing path-traversal or absolute
+  # entries before extracting, even though the checksum above already ties
+  # the archive to the signed release.
+  if tar -tf "${TMPDIR_WORK}/${archive}" | grep -qE '(^|/)\.\.(/|$)|^/'; then
+    red "Archive ${archive} contains unsafe paths (.. or absolute) — aborting"
+    exit 1
+  fi
+
+  tar --no-same-owner -xf "${TMPDIR_WORK}/${archive}" -C "${TMPDIR_WORK}/"
   mv "${TMPDIR_WORK}/claudebar" "$BIN_DEST"
   chmod +x "$BIN_DEST"
   green "claudebar ${tag} installed to ${BIN_DEST}"
@@ -281,65 +303,24 @@ if [ -z "$COMMAND_VALUE" ]; then
       COMMAND_VALUE="${BIN_DEST} render"
       green "claudebar built and installed to ${BIN_DEST}"
     else
-      red "cargo build failed — falling back to statusline-command.sh"
+      red "cargo build failed."
     fi
   elif [ -z "$SRC_DIR" ]; then
-    bold "No local checkout detected — cargo install requires source; falling back to statusline-command.sh"
+    bold "No local checkout detected — cargo build requires source."
   else
-    bold "cargo not found — falling back to statusline-command.sh"
+    bold "cargo not found."
   fi
 fi
 
-# Tier 3: Bash script fallback
 if [ -z "$COMMAND_VALUE" ]; then
-  bold "Installing statusline-command.sh (bash fallback — requires jq + git at runtime)"
-  curl -fsSL "$REPO/statusline-command.sh" -o "${TMPDIR_WORK}/statusline-command.sh"
-  if [ ! -s "${TMPDIR_WORK}/statusline-command.sh" ]; then
-    red "Download failed — file is empty"
-    exit 1
-  fi
-  mv "${TMPDIR_WORK}/statusline-command.sh" "$SCRIPT_DEST"
-  chmod +x "$SCRIPT_DEST"
-  green "statusline-command.sh installed to ${SCRIPT_DEST}"
-  COMMAND_VALUE="bash ~/.claude/statusline-command.sh"
+  red "No installation method succeeded (no prebuilt binary for this platform and no local cargo build available)."
+  echo "Install Rust (https://rustup.rs) and re-run from a checkout, or wait for a prebuilt release for your platform."
+  exit 1
 fi
 
 # ── Configure statusLine ─────────────────────────────────────────────────────────
-# Tier 1/2 installed a real claudebar binary at $BIN_DEST — reuse its own
-# setup subcommand (single source of truth for the merge/backup/diff logic).
-# Tier 3 (bash-script-only fallback) never installs a compiled binary, so it
-# keeps the pre-existing jq-based merge.
-if [ -x "$BIN_DEST" ]; then
-  "$BIN_DEST" setup --yes --binary-path "$BIN_DEST"
-  link_onto_path
-else
-  if [ -f "$SETTINGS" ]; then
-    if ! command -v jq >/dev/null 2>&1; then
-      red "$SETTINGS already exists but jq is not installed."
-      echo "Install jq, or add this manually to $SETTINGS:"
-      printf '  "statusLine": {"type":"command","command":"%s"}\n' "$COMMAND_VALUE"
-      exit 1
-    fi
-    backup="${SETTINGS}.backup.$(date +%s)"
-    cp "$SETTINGS" "$backup"
-    printf 'Backed up settings.json to %s\n' "$backup"
-    status_line=$(jq -nc --arg c "$COMMAND_VALUE" '{type:"command",command:$c}')
-    tmp_cfg=$(mktemp)
-    if ! jq --argjson v "$status_line" '.statusLine = $v' "$SETTINGS" > "$tmp_cfg"; then
-      red "$SETTINGS is not valid JSON — fix it manually before re-running."
-      rm -f "$tmp_cfg"
-      exit 1
-    fi
-    mv "$tmp_cfg" "$SETTINGS"
-  else
-    cat > "$SETTINGS" <<EOF
-{
-  "statusLine": { "type": "command", "command": "$COMMAND_VALUE" }
-}
-EOF
-  fi
-  green "settings.json updated"
-fi
+"$BIN_DEST" setup --yes --binary-path "$BIN_DEST"
+link_onto_path
 
 # ── Done ───────────────────────────────────────────────────────────────────────
 echo ""

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -1,12 +1,14 @@
 #!/usr/bin/env bats
-# Light Bats coverage for install.sh — syntax check only. install.sh runs its
-# full install flow at top level (no `main` guard) and its happy path calls
-# out to the GitHub releases API, so a live/networked run is deliberately out
-# of scope here; that path is already covered by .github/workflows/verify-install.yml.
+# Bats coverage for install.sh. The script guards its entry point
+# (main runs only when executed, not sourced), so tests source it directly
+# and exercise individual functions. The networked happy path is covered
+# by .github/workflows/verify-install.yml.
 
 setup() {
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
   INSTALL="$REPO_ROOT/install.sh"
+  source "$INSTALL"
+  cd "$BATS_TEST_TMPDIR"
 }
 
 @test "install.sh is syntactically valid" {
@@ -14,47 +16,167 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-# verify_checksum is tested in isolation by extracting the function (plus
-# sha256_of) from the script — the top-level install flow never runs.
-extract_verify_checksum() {
-  sed -n '/^sha256_of()/,/^}/p; /^verify_checksum()/,/^}/p' "$INSTALL"
-  echo 'red() { echo "$@"; }; green() { echo "$@"; }'
+@test "sourcing install.sh does not run the installer" {
+  run bash -c "source '$INSTALL'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
 }
 
+# ── detect_target ──────────────────────────────────────────────────────────────
+
+@test "detect_target honors CLAUDEBAR_TARGET override" {
+  CLAUDEBAR_TARGET="aarch64-apple-darwin" run detect_target
+  [ "$output" = "aarch64-apple-darwin" ]
+}
+
+@test "detect_target maps Linux x86_64 to musl triple" {
+  uname() { case "$1" in -s) echo Linux ;; -m) echo x86_64 ;; esac; }
+  export -f uname
+  CLAUDEBAR_TARGET="" run detect_target
+  [ "$output" = "x86_64-unknown-linux-musl" ]
+}
+
+@test "detect_target maps Darwin arm64 to apple triple" {
+  uname() { case "$1" in -s) echo Darwin ;; -m) echo arm64 ;; esac; }
+  export -f uname
+  CLAUDEBAR_TARGET="" run detect_target
+  [ "$output" = "aarch64-apple-darwin" ]
+}
+
+@test "detect_target prints nothing for unsupported arch" {
+  uname() { case "$1" in -s) echo Linux ;; -m) echo riscv64 ;; esac; }
+  export -f uname
+  CLAUDEBAR_TARGET="" run detect_target
+  [ -z "$output" ]
+}
+
+# ── release JSON parsing ───────────────────────────────────────────────────────
+
+@test "release_tag extracts the tag" {
+  run release_tag '{"tag_name":"v1.2.3"}'
+  [ "$output" = "v1.2.3" ]
+}
+
+@test "release_tag is empty when no release exists" {
+  run release_tag '{"message":"Not Found"}'
+  [ -z "$output" ]
+}
+
+@test "find_asset_url resolves an asset by regex" {
+  json='{"assets":[{"name":"claudebar-x86_64-unknown-linux-musl.tar.gz","browser_download_url":"https://github.com/x/y/releases/download/v1/claudebar-x86_64-unknown-linux-musl.tar.gz"}]}'
+  run find_asset_url "$json" '^claudebar-x86_64-unknown-linux-musl\.tar\.gz$'
+  [[ "$output" == https://github.com/*musl.tar.gz ]]
+}
+
+@test "find_asset_url is empty when nothing matches" {
+  run find_asset_url '{"assets":[{"name":"other.zip","browser_download_url":"https://github.com/x"}]}' '^claudebar-.*\.tar\.gz$'
+  [ -z "$output" ]
+}
+
+# ── require_github_host ────────────────────────────────────────────────────────
+
+@test "require_github_host accepts github.com URLs" {
+  run require_github_host "https://github.com/micschr0/claudebar/releases/download/v1/x.tar.gz"
+  [ "$status" -eq 0 ]
+}
+
+@test "require_github_host rejects other hosts" {
+  run require_github_host "https://evil.example.com/x.tar.gz"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"untrusted host"* ]]
+}
+
+@test "require_github_host rejects plain http" {
+  run require_github_host "http://github.com/micschr0/claudebar/x.tar.gz"
+  [ "$status" -eq 1 ]
+}
+
+@test "require_github_host rejects lookalike domains" {
+  run require_github_host "https://github.com.evil.example/x.tar.gz"
+  [ "$status" -eq 1 ]
+}
+
+# ── verify_checksum ────────────────────────────────────────────────────────────
+
 @test "verify_checksum accepts text-mode sums (hash  name)" {
-  cd "$BATS_TEST_TMPDIR"
   echo hello > file.tar.gz
-  hash=$(sha256sum file.tar.gz | awk '{print $1}')
-  printf '%s  file.tar.gz\n' "$hash" > sha256.sum
-  run bash -c "$(extract_verify_checksum); verify_checksum file.tar.gz file.tar.gz sha256.sum"
+  printf '%s  file.tar.gz\n' "$(sha256_of file.tar.gz)" > sha256.sum
+  run verify_checksum file.tar.gz file.tar.gz sha256.sum
   [ "$status" -eq 0 ]
 }
 
 @test "verify_checksum accepts binary-mode sums (hash *name)" {
-  cd "$BATS_TEST_TMPDIR"
   echo hello > file.tar.gz
-  hash=$(sha256sum file.tar.gz | awk '{print $1}')
-  printf '%s *file.tar.gz\n' "$hash" > sha256.sum
-  run bash -c "$(extract_verify_checksum); verify_checksum file.tar.gz file.tar.gz sha256.sum"
+  printf '%s *file.tar.gz\n' "$(sha256_of file.tar.gz)" > sha256.sum
+  run verify_checksum file.tar.gz file.tar.gz sha256.sum
   [ "$status" -eq 0 ]
 }
 
 @test "verify_checksum rejects a tampered file" {
-  cd "$BATS_TEST_TMPDIR"
   echo hello > file.tar.gz
-  hash=$(sha256sum file.tar.gz | awk '{print $1}')
-  printf '%s *file.tar.gz\n' "$hash" > sha256.sum
+  printf '%s *file.tar.gz\n' "$(sha256_of file.tar.gz)" > sha256.sum
   echo tampered >> file.tar.gz
-  run bash -c "$(extract_verify_checksum); verify_checksum file.tar.gz file.tar.gz sha256.sum"
+  run verify_checksum file.tar.gz file.tar.gz sha256.sum
   [ "$status" -eq 1 ]
   [[ "$output" == *"SHA256 mismatch"* ]]
 }
 
 @test "verify_checksum fails on a missing entry" {
-  cd "$BATS_TEST_TMPDIR"
   echo hello > file.tar.gz
   printf 'deadbeef *other.tar.gz\n' > sha256.sum
-  run bash -c "$(extract_verify_checksum); verify_checksum file.tar.gz file.tar.gz sha256.sum"
+  run verify_checksum file.tar.gz file.tar.gz sha256.sum
   [ "$status" -eq 1 ]
   [[ "$output" == *"No checksum entry"* ]]
+}
+
+# ── archive safety ─────────────────────────────────────────────────────────────
+
+@test "archive_has_unsafe_paths passes a clean archive" {
+  echo bin > claudebar
+  tar -czf clean.tar.gz claudebar
+  run archive_has_unsafe_paths clean.tar.gz
+  [ "$status" -eq 1 ]
+}
+
+@test "archive_has_unsafe_paths flags path traversal" {
+  mkdir -p sub
+  echo evil > sub/x
+  tar -czf evil.tar.gz --transform 's|sub/x|../escape|' sub/x
+  run archive_has_unsafe_paths evil.tar.gz
+  [ "$status" -eq 0 ]
+}
+
+@test "extract_archive extracts a clean archive" {
+  echo bin > claudebar
+  tar -czf clean.tar.gz claudebar
+  mkdir out
+  run extract_archive clean.tar.gz out
+  [ "$status" -eq 0 ]
+  [ -f out/claudebar ]
+}
+
+@test "extract_archive refuses a traversal archive" {
+  mkdir -p sub
+  echo evil > sub/x
+  tar -czf evil.tar.gz --transform 's|sub/x|../escape|' sub/x
+  mkdir out
+  run extract_archive evil.tar.gz out
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unsafe paths"* ]]
+  [ ! -e escape ]
+}
+
+# ── install_from_source guards ─────────────────────────────────────────────────
+
+@test "install_from_source fails without a source dir" {
+  run install_from_source ""
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No local checkout"* ]]
+}
+
+@test "install_from_source fails without Cargo.toml" {
+  mkdir empty-checkout
+  run install_from_source "$PWD/empty-checkout"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No Cargo.toml"* ]]
 }


### PR DESCRIPTION
## Problem

Three segments (Clock, Cost, Burn) had visibly wider gaps than the other five. The eye reads uneven spacing as a rhythm disruption — a violation of the Gestalt law of similarity.

**Root cause:** `w.icon()` already appends a trailing space after the glyph. The manual `w.raw(" ")` calls inside `colored_with` closures created double-spacing. Other segments (Directory, Git, Model, Context, RateLimits) never did this — they relied solely on `icon()` for their leading padding.

## Fix

Removes redundant `w.raw(" ")` calls in Clock, Cost, and Burn:

| Segment | Before | After |
|---------|--------|-------|
| Clock | `<icon>  15:18 ` | `<icon> 15:18` |
| Cost | `<icon>  $1.23 ` | `<icon> $1.23` |
| Burn | `<icon>  5h ⇢ 42m ` | `<icon> 5h ⇢ 42m` |

Burn status indicators (" … ", " ✓ ") tightened to "…" / "✓" — `icon()` provides the leading space.

## Design rationale

- `icon()` already owns the trailing-space convention — segments must not duplicate it
- The inter-segment separator (`" "` + glyph + `" "`) provides consistent gaps
- All 8 default segments now share the same visual rhythm

**Gap uniformity before/after** (visible spaces between segment contents, excluding glyphs):

| Transition | Before | After |
|------------|--------|-------|
| Directory → Git | 2 | 2 |
| Git → Model | 2 | 2 |
| Model → Context | 2 | 2 |
| Context → RateLimits | 2 | 2 |
| **RateLimits → Cost** | **3** | **2** |
| **Cost → Burn** | **4** | **2** |
| **Burn → Clock** | **4** | **2** |

Gap dispersion: `[2,2,2,2,3,4,4]` (range 2) → `[2,2,2,2,2,2,2]` (range 0).

## Tested

- 234/234 tests pass
- Visual smoke test confirms uniform spacing with `fixtures/typical.json`