### PR TITLE
Release artifact attestations + SECURITY.md (#19)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,6 +282,10 @@ jobs:
           rm -f artifacts/*-dist-manifest.json
       - name: Generate artifact attestations
         if: ${{ needs.plan.outputs.dry_run != 'true' }}
+        # Defense-in-depth, not a hard gate — a transient attestation-service
+        # outage must never block shipping a release (matches install.sh's
+        # non-fatal verify_attestation() framing).
+        continue-on-error: true
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: "artifacts/claudebar-*.tar.gz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,6 +218,8 @@ jobs:
   host:
     permissions:
       contents: write
+      attestations: write
+      id-token: write
     needs:
       - plan
       - build-local-artifacts
@@ -278,6 +280,11 @@ jobs:
         run: |
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
+      - name: Generate artifact attestations
+        if: ${{ needs.plan.outputs.dry_run != 'true' }}
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: "artifacts/claudebar-*.tar.gz"
       - name: Create GitHub Release
         if: ${{ needs.plan.outputs.dry_run != 'true' }}
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -70,6 +70,8 @@ jobs:
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         with:
           config-path: .gitleaks.toml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   zizmor:
     name: zizmor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Security
-- Attest release artifacts with GitHub build provenance (`actions/attest-build-provenance`); `install.sh` verifies it non-fatally via `gh attestation verify` after the SHA256 gate (#27, closes #19)
-- Add `SECURITY.md` (supported versions, private vulnerability reporting) and document `gh attestation verify` in the README
-
 ### Fixed
 - Swap duration glyph to stopwatch in the powerline style
 - Remove duplicate Nerd Font tip in `install.sh`
@@ -19,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Tests
 - Add bats test suite for `statusline-command.sh` and `install.sh`; replace the smoke job in CI
 - Exercise the weekly-window gap glyph in the golden-snapshot suite and live TUI preview by crossing the `weekly_show_at` threshold
+
+### Security
+- Attest release artifacts with GitHub build provenance (`actions/attest-build-provenance`); `install.sh` verifies it non-fatally via `gh attestation verify` after the SHA256 gate (#27, closes #19)
+- Add `SECURITY.md` (supported versions, private vulnerability reporting) and document `gh attestation verify` in the README
 
 ## [2026.7.3] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Attest release artifacts with GitHub build provenance (`actions/attest-build-provenance`); `install.sh` verifies it non-fatally via `gh attestation verify` after the SHA256 gate (#27, closes #19)
+- Add `SECURITY.md` (supported versions, private vulnerability reporting) and document `gh attestation verify` in the README
+
 ### Fixed
 - Swap duration glyph to stopwatch in the powerline style
 - Remove duplicate Nerd Font tip in `install.sh`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,17 @@ ci = ["github"]
 # which diverges from what cargo-dist generates. Accept this drift.
 allow-dirty = ["ci"]
 hosting = ["github"]
+# GitHub Artifact Attestations (issue #19). cargo-dist 0.32.0 supports these keys
+# natively; declared so a future deliberate `dist generate ci` regen stays
+# structurally consistent. The attest step's SHA pin in release.yml is still
+# maintained by hand, like every other `uses:` line (see allow-dirty above).
+github-attestations = true
+# Globed against "artifacts/{filter}" in the host phase — binaries only, not
+# installer scripts, checksums, or manifests.
+github-attestations-filters = ["claudebar-*.tar.gz"]
+# Attest once against the final collected release assets. The default
+# (build-local-artifacts) would attest per-target before aggregation.
+github-attestations-phase = "host"
 
 # Pin only the ARM macOS build to macos-14. The Intel macOS build uses dist's default
 # runner image (its old fixed pin was dropped — GitHub is retiring that hosted runner).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,22 +79,6 @@ ci = ["github"]
 # which diverges from what cargo-dist generates. Accept this drift.
 allow-dirty = ["ci"]
 hosting = ["github"]
-# GitHub Artifact Attestations (issue #19). cargo-dist 0.32.0 accepts these keys,
-# but a `dist generate --mode=ci` regen would emit its own step
-# (`actions/attest@v4`, unpinned, no dry-run gate) — not the hand-written,
-# SHA-pinned, dry-run-gated step in release.yml below. That's fine in practice:
-# `allow-dirty = ["ci"]` above already tells dist to leave release.yml alone, so
-# `dist generate --check` (the CI drift gate in rust.yml) passes cleanly and a
-# routine regen can't silently overwrite this step. Only a manual, deliberate
-# `dist generate --mode=ci` run would replace it — re-apply this hand-written
-# step afterward if that ever happens.
-github-attestations = true
-# Globed against "artifacts/{filter}" in the host phase — binaries only, not
-# installer scripts, checksums, or manifests.
-github-attestations-filters = ["claudebar-*.tar.gz"]
-# Attest once against the final collected release assets. The default
-# (build-local-artifacts) would attest per-target before aggregation.
-github-attestations-phase = "host"
 
 # Pin only the ARM macOS build to macos-14. The Intel macOS build uses dist's default
 # runner image (its old fixed pin was dropped — GitHub is retiring that hosted runner).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,10 +79,15 @@ ci = ["github"]
 # which diverges from what cargo-dist generates. Accept this drift.
 allow-dirty = ["ci"]
 hosting = ["github"]
-# GitHub Artifact Attestations (issue #19). cargo-dist 0.32.0 supports these keys
-# natively; declared so a future deliberate `dist generate ci` regen stays
-# structurally consistent. The attest step's SHA pin in release.yml is still
-# maintained by hand, like every other `uses:` line (see allow-dirty above).
+# GitHub Artifact Attestations (issue #19). cargo-dist 0.32.0 accepts these keys,
+# but a `dist generate --mode=ci` regen would emit its own step
+# (`actions/attest@v4`, unpinned, no dry-run gate) — not the hand-written,
+# SHA-pinned, dry-run-gated step in release.yml below. That's fine in practice:
+# `allow-dirty = ["ci"]` above already tells dist to leave release.yml alone, so
+# `dist generate --check` (the CI drift gate in rust.yml) passes cleanly and a
+# routine regen can't silently overwrite this step. Only a manual, deliberate
+# `dist generate --mode=ci` run would replace it — re-apply this hand-written
+# step afterward if that ever happens.
 github-attestations = true
 # Globed against "artifacts/{filter}" in the host phase — binaries only, not
 # installer scripts, checksums, or manifests.

--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ Restart Claude Code and the statusline is live. If anything looks off, `claudeba
 
 ## Verify a release
 
-Every `claudebar-*.tar.gz` release asset carries a [GitHub artifact attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) proving it was built by this repository's release workflow:
+Every `claudebar-*.tar.gz` release asset carries a [GitHub artifact attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations). Verify it was signed by this repository's release workflow specifically (not just any workflow in the repo):
 
 ```bash
-gh attestation verify claudebar-<target>.tar.gz --repo micschr0/claudebar
+gh attestation verify claudebar-<target>.tar.gz \
+  --repo micschr0/claudebar \
+  --signer-workflow micschr0/claudebar/.github/workflows/release.yml
 ```
 
 `<target>` is your platform triple, e.g. `x86_64-unknown-linux-musl` or `aarch64-apple-darwin`. `install.sh` runs this check automatically when `gh` is installed and authenticated; when it isn't, the install continues — the SHA256 checksum remains the mandatory integrity gate.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ Restart Claude Code and the statusline is live. If anything looks off, `claudeba
 > [!NOTE]
 > Powerline glyphs need a [Nerd Font](https://www.nerdfonts.com/); the `ascii` style needs none.
 
+## Verify a release
+
+Every `claudebar-*.tar.gz` release asset carries a [GitHub artifact attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) proving it was built by this repository's release workflow:
+
+```bash
+gh attestation verify claudebar-<target>.tar.gz --repo micschr0/claudebar
+```
+
+`<target>` is your platform triple, e.g. `x86_64-unknown-linux-musl` or `aarch64-apple-darwin`. `install.sh` runs this check automatically when `gh` is installed and authenticated; when it isn't, the install continues — the SHA256 checksum remains the mandatory integrity gate.
+
 ## States (< 50% / 50–80% / > 80%)
 
 <img src="screenshots/strip-normal.png" width="860" alt="Normal: calm baseline">

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+claudebar uses [CalVer](https://calver.org/) (`YYYY.M.D`) with no maintained
+LTS branches. Only the latest published release receives security fixes.
+
+| Version         | Supported          |
+| ---------------- | ------------------ |
+| Latest (2026.7.3) | :white_check_mark: |
+| Older releases    | :x:                |
+
+## Reporting a Vulnerability
+
+Do not open a public GitHub issue for security vulnerabilities. Instead, use
+GitHub's private reporting flow:
+[Report a vulnerability](https://github.com/micschr0/claudebar/security/advisories/new).
+
+Include:
+
+- A description of the vulnerability and its impact.
+- Reproduction steps. For render-pipeline issues, a minimal JSON input in the
+  style of `fixtures/*.json` is the fastest repro path.
+- The affected version (`claudebar --version`).
+
+claudebar is solo-maintained. Expect a best-effort acknowledgment within a
+few days — there is no formal SLA.
+
+Release artifacts carry GitHub artifact attestations; see
+[Verify a release](README.md#verify-a-release) to confirm a download's
+provenance.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,10 +5,10 @@
 claudebar uses [CalVer](https://calver.org/) (`YYYY.M.D`) with no maintained
 LTS branches. Only the latest published release receives security fixes.
 
-| Version         | Supported          |
-| ---------------- | ------------------ |
-| Latest (2026.7.3) | :white_check_mark: |
-| Older releases    | :x:                |
+| Version                | Supported          |
+| ---------------------- | ------------------ |
+| Latest published release | :white_check_mark: |
+| Older releases         | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/install.sh
+++ b/install.sh
@@ -130,6 +130,28 @@ verify_checksum() {
   green "SHA256 verified"
 }
 
+# Build-provenance check via GitHub artifact attestations. Defense-in-depth on
+# top of the mandatory SHA256 gate — informative, never fatal. gh needs auth
+# even for public repos, so unauthenticated gh counts as skipped, not failed.
+verify_attestation() {
+  local file="$1"
+  if ! command -v gh >/dev/null 2>&1; then
+    bold "Provenance check skipped (gh CLI not installed)"
+    return 0
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    bold "Provenance check skipped (gh CLI not authenticated)"
+    return 0
+  fi
+  bold "Verifying build provenance (gh attestation verify)..."
+  if gh attestation verify "$file" --repo micschr0/claudebar >/dev/null 2>&1; then
+    green "Build provenance verified — artifact was built by this repo's release workflow"
+  else
+    red "Provenance verification failed or no attestation found — continuing (SHA256 already verified)"
+  fi
+  return 0
+}
+
 archive_has_unsafe_paths() {
   tar -tf "$1" | grep -qE '(^|/)\.\.(/|$)|^/'
 }
@@ -186,6 +208,7 @@ install_prebuilt() {
   fi
   curl_https "$sums_url" -o "${workdir}/sha256.sum"
   verify_checksum "${workdir}/${archive}" "$archive" "${workdir}/sha256.sum" || exit 1
+  verify_attestation "${workdir}/${archive}"
 
   extract_archive "${workdir}/${archive}" "$workdir" || exit 1
   install_binary "${workdir}/claudebar"

--- a/install.sh
+++ b/install.sh
@@ -133,10 +133,16 @@ verify_checksum() {
 # Build-provenance check via GitHub artifact attestations. Defense-in-depth on
 # top of the mandatory SHA256 gate — informative, never fatal. gh needs auth
 # even for public repos, so unauthenticated gh counts as skipped, not failed.
+# --signer-workflow scopes trust to release.yml specifically; --repo alone only
+# proves the attestation belongs to this repo, not that release.yml signed it.
 verify_attestation() {
   local file="$1"
   if ! command -v gh >/dev/null 2>&1; then
     bold "Provenance check skipped (gh CLI not installed)"
+    return 0
+  fi
+  if ! gh attestation --help >/dev/null 2>&1; then
+    bold "Provenance check skipped (gh CLI too old — 'gh attestation' unavailable)"
     return 0
   fi
   if ! gh auth status >/dev/null 2>&1; then
@@ -144,10 +150,13 @@ verify_attestation() {
     return 0
   fi
   bold "Verifying build provenance (gh attestation verify)..."
-  if gh attestation verify "$file" --repo micschr0/claudebar >/dev/null 2>&1; then
+  if gh attestation verify "$file" \
+    --repo micschr0/claudebar \
+    --signer-workflow micschr0/claudebar/.github/workflows/release.yml \
+    >/dev/null 2>&1; then
     green "Build provenance verified — artifact was built by this repo's release workflow"
   else
-    red "Provenance verification failed or no attestation found — continuing (SHA256 already verified)"
+    red "Provenance verification failed — no matching attestation found, continuing (SHA256 already verified)"
   fi
   return 0
 }

--- a/install.sh
+++ b/install.sh
@@ -136,7 +136,7 @@ verify_checksum() {
 # --signer-workflow scopes trust to release.yml specifically; --repo alone only
 # proves the attestation belongs to this repo, not that release.yml signed it.
 verify_attestation() {
-  local file="$1"
+  local file="$1" out
   if ! command -v gh >/dev/null 2>&1; then
     bold "Provenance check skipped (gh CLI not installed)"
     return 0
@@ -150,13 +150,14 @@ verify_attestation() {
     return 0
   fi
   bold "Verifying build provenance (gh attestation verify)..."
-  if gh attestation verify "$file" \
+  if out=$(gh attestation verify "$file" \
     --repo micschr0/claudebar \
     --signer-workflow micschr0/claudebar/.github/workflows/release.yml \
-    >/dev/null 2>&1; then
+    2>&1); then
     green "Build provenance verified — artifact was built by this repo's release workflow"
   else
-    red "Provenance verification failed — no matching attestation found, continuing (SHA256 already verified)"
+    red "Provenance verification failed, continuing (SHA256 already verified):"
+    printf '%s\n' "$out" >&2
   fi
   return 0
 }

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -129,6 +129,70 @@ setup() {
   [[ "$output" == *"No checksum entry"* ]]
 }
 
+# ── verify_attestation ──────────────────────────────────────────────────────────
+# Always non-fatal by design (status 0 on every branch) — assert that explicitly
+# alongside each outcome's message, since a regressed `return 1` would still let
+# the SHA256 gate mask the break in install_prebuilt().
+
+@test "verify_attestation skips when gh is not installed" {
+  command() { if [ "$1" = -v ] && [ "$2" = gh ]; then return 1; fi; builtin command "$@"; }
+  run verify_attestation file.tar.gz
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"gh CLI not installed"* ]]
+}
+
+@test "verify_attestation skips when gh predates the attestation subcommand" {
+  gh() { [ "$*" = "attestation --help" ] && return 1; return 1; }
+  export -f gh
+  run verify_attestation file.tar.gz
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"gh CLI too old"* ]]
+}
+
+@test "verify_attestation skips when gh is not authenticated" {
+  gh() {
+    case "$*" in
+      "attestation --help") return 0 ;;
+      "auth status") return 1 ;;
+    esac
+    return 1
+  }
+  export -f gh
+  run verify_attestation file.tar.gz
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not authenticated"* ]]
+}
+
+@test "verify_attestation reports success when gh verifies" {
+  gh() {
+    case "$*" in
+      "attestation --help") return 0 ;;
+      "auth status") return 0 ;;
+      "attestation verify "*"--signer-workflow micschr0/claudebar/.github/workflows/release.yml") return 0 ;;
+    esac
+    return 1
+  }
+  export -f gh
+  run verify_attestation file.tar.gz
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Build provenance verified"* ]]
+}
+
+@test "verify_attestation reports failure without aborting the install" {
+  gh() {
+    case "$*" in
+      "attestation --help") return 0 ;;
+      "auth status") return 0 ;;
+      "attestation verify "*) return 1 ;;
+    esac
+    return 1
+  }
+  export -f gh
+  run verify_attestation file.tar.gz
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Provenance verification failed"* ]]
+}
+
 # ── archive safety ─────────────────────────────────────────────────────────────
 
 @test "archive_has_unsafe_paths passes a clean archive" {


### PR DESCRIPTION
## Summary
- Wire GitHub Artifact Attestations into the release workflow: `release.yml`'s host job gains `attestations:write` + `id-token:write` and a hand-written, SHA-pinned `actions/attest-build-provenance` step (scoped to `claudebar-*.tar.gz`, dry-run-gated, `continue-on-error`)
- `install.sh` opportunistically verifies the attestation after the checksum gate via `verify_attestation()` — never blocks the install, distinct message per outcome (skip-no-gh, skip-unauth, pass, fail)
- Add `SECURITY.md` (supported versions, private vulnerability reporting via GitHub advisories)
- README documents the manual `gh attestation verify` command

Closes #19.

## Review follow-ups
- `install.sh`: `verify_attestation()` now captures `gh attestation verify` output and prints it on stderr when verification fails, instead of discarding it — a transient/service failure no longer masquerades as a generic "no matching attestation" message. Still non-fatal (`return 0` on every branch).
- `Cargo.toml`: dropped the `github-attestations*` dist keys (and their comment). They were inert — `allow-dirty = ["ci"]` keeps `dist` from regenerating `release.yml`, so the keys never produced a step and only duplicated the hand-written one. `dist generate --check` still passes.

## Test plan
- [x] `Cargo.toml` / `release.yml` parse as valid TOML/YAML; `uses:` line SHA-pinned
- [x] `bash -n install.sh` passes; `verify_attestation()` returns 0 on every branch; all 29 bats tests green
- [x] README/SECURITY.md content checks (grep-verified against plan's `must_haves`)
- [ ] End-to-end: next tagged release shows a green "Generate artifact attestations" step and `gh attestation verify` succeeds against a downloaded asset (deferred — needs a real tag)
