### PR TITLE
ci: use prebuilt cargo-dist and unify checkout to v7

### DIFF
--- a/.github/workflows/homebrew-app-token.yml
+++ b/.github/workflows/homebrew-app-token.yml
@@ -30,7 +30,7 @@ jobs:
           owner: "micschr0"
           repositories: "homebrew-tap"
           permission-contents: write
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: true
           repository: "micschr0/homebrew-tap"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: renovatebot/github-action@6d859fc95779be83a0335ca704879b47e5d79641 # v46.1.16
         with:
           configurationFile: renovate.json

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,9 @@ jobs:
       - name: Check release profile (auditable)
         run: cargo auditable build --release --locked
       - name: Install dist (pinned to Cargo.toml cargo-dist-version)
-        run: cargo install cargo-dist@0.32.0 --locked
+        uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2
+        with:
+          tool: cargo-dist@0.32.0
 
       - name: dist workflow drift check
         run: dist generate --check


### PR DESCRIPTION
## Summary
- Install `cargo-dist` via `taiki-e/install-action` (prebuilt binary) instead of `cargo install`, matching the existing `cargo-audit` pattern
- Bump the two remaining `actions/checkout@...# v6` occurrences (renovate.yml, homebrew-app-token.yml) to the v7 SHA used everywhere else

## Test plan
- [x] YAML validity check on all changed workflow files
- [x] Confirmed zero `checkout@df4cb1c...# v6` occurrences remain
- [x] Confirmed no unpinned `uses:` introduced
- [x] Confirmed `cargo install cargo-dist` removed from rust.yml

Closes #26.