### PR TITLE
feat(install): add CLAUDEBAR_CHANNEL=beta for prerelease testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `claudebar setup` prints a restart reminder after wiring up `settings.json`, matching the installer
+- `install.sh` supports a beta channel (`CLAUDEBAR_CHANNEL=beta`) that installs the latest prerelease for testing before a stable release
 
 ### Fixed
 - `install.sh`: add `--force` to `setup` call so an existing `statusLine` in `settings.json` doesn't abort the install script before `link_onto_path` and the success message

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ bash install.sh
 ```
 </details>
 
+<details><summary>Try a beta before it's stable</summary>
+
+Prereleases (tagged e.g. `2026.7.6-beta.1`) are built and published like any other release, just marked as a prerelease — `install.sh` normally only ever installs the latest stable one. To try the newest prerelease instead:
+
+```bash
+CLAUDEBAR_CHANNEL=beta curl -fsSL https://raw.githubusercontent.com/micschr0/claudebar/main/install.sh | bash
+```
+
+Switch back to stable any time by reinstalling without the env var. Homebrew always tracks stable.
+</details>
+
 ## What it looks like
 
 Colors shift as usage crosses **50%** and **80%**:

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 # install.sh — one-command installer for claudebar
 # Usage: curl -fsSL https://raw.githubusercontent.com/micschr0/claudebar/main/install.sh | bash
+# Beta channel (latest prerelease, may be unstable):
+#   CLAUDEBAR_CHANNEL=beta curl -fsSL https://raw.githubusercontent.com/micschr0/claudebar/main/install.sh | bash
 set -euo pipefail
 
 BIN_DEST="$HOME/.claude/claudebar"
-RELEASE_API="https://api.github.com/repos/micschr0/claudebar/releases/latest"
+RELEASE_CHANNEL="${CLAUDEBAR_CHANNEL:-stable}"
+case "$RELEASE_CHANNEL" in
+  stable) RELEASE_API="https://api.github.com/repos/micschr0/claudebar/releases/latest" ;;
+  beta)   RELEASE_API="https://api.github.com/repos/micschr0/claudebar/releases" ;;
+  *)
+    printf '\033[31mUnknown CLAUDEBAR_CHANNEL: %s (expected: stable, beta)\033[0m\n' "$RELEASE_CHANNEL" >&2
+    exit 1
+    ;;
+esac
 
 red()   { printf '\033[31m%s\033[0m\n' "$*"; }
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
@@ -73,6 +83,11 @@ LATEST_RELEASE_JSON=""
 fetch_latest_release() {
   if [ -z "$LATEST_RELEASE_JSON" ]; then
     LATEST_RELEASE_JSON=$(curl_https "$RELEASE_API")
+    # beta channel hits the /releases list (newest first, includes prereleases);
+    # stable hits /releases/latest, which is already a single object.
+    if [ "$RELEASE_CHANNEL" = "beta" ]; then
+      LATEST_RELEASE_JSON=$(printf '%s' "$LATEST_RELEASE_JSON" | jq -c '.[0] // empty')
+    fi
   fi
   printf '%s' "$LATEST_RELEASE_JSON"
 }
@@ -316,6 +331,10 @@ workdir=""
 
 main() {
   local src_dir target installed=1
+
+  if [ "$RELEASE_CHANNEL" = "beta" ]; then
+    bold "⚠ Beta channel — installing the latest prerelease, which may be unstable."
+  fi
 
   check_dependencies
   mkdir -p "$HOME/.claude"


### PR DESCRIPTION
## What
Cherry-picked `5d0dfe9` ("feat: add beta install channel for testing prereleases") from `feature/beta-release-channel`.

Adds `CLAUDEBAR_CHANNEL` env-var support to `install.sh`:
- `stable` (default, current behavior) — `/releases/latest`
- `beta` — `/releases` list, picks newest entry (includes prereleases)
- anything else — exits 1 with red error

Also adds:
- Beta-warning banner at the top of the install summary if the channel is `beta`.
- `<details>` block in README documenting how to try a beta.
- `CHANGELOG.md` bullet under the current unreleased section.

## Why
cargo-dist already publishes tags like `2026.7.6-beta.1` as GitHub prereleases and skips Homebrew publishing for them, but there was no path for users to actually consume those prereleases via the bash installer. This closes that gap.

## Source-branch triage (informational)
Of the 3 commits on `feature/beta-release-channel`:
- `8c7058d` and `0117293` are duplicates of `main` commits; cherry-picking them would re-introduce destructive rollbacks (lost Renovate App-token, lost checkout@v7, lost concurrency). They were correctly skipped.
- `5d0dfe9` (this PR) is the only net-new and was independently reviewed as KEEP.

## Verification
- `bash -n install.sh` — OK
- `shellcheck install.sh` — 0 findings
- `CLAUDEBAR_CHANNEL=garbage bash install.sh` — exits 1 with the expected red error
- `CLAUDEBAR_CHANNEL=beta …` source resolves `RELEASE_API=https://api.github.com/repos/micschr0/claudebar/releases` (correct list endpoint)
- `git diff main..HEAD --stat` — `install.sh: +20/-1`, `README.md: +11`, `CHANGELOG.md: +1`

## Out of scope
Recommend closing `feature/beta-release-channel` after merge — its 2 duplicate commits contain destructive rollbacks against current `main`.