### PR TITLE
chore: drop 'gsd-executor' reference from video demo fixture

### DIFF
--- a/video/scripts/gen_optional_segments.py
+++ b/video/scripts/gen_optional_segments.py
@@ -105,7 +105,7 @@ SHOTS = [
     ("dev-context", "dev-context", {
         "worktree": {"name": "feature-render-cache"},
         "pr": {"number": 482, "review_state": "ok"},
-        "agent": {"name": "gsd-executor"},
+        "agent": {"name": "claude-code"},
     }, None),
     ("clock", "clock", {}, None),
 ]


### PR DESCRIPTION
## What
One-character rename in `video/scripts/gen_optional_segments.py`:
`"gsd-executor"` → `"claude-code"` in the `dev-context` shot's fixture data.

## Why
Tidies up the last tracked GSD reference. The substantive cleanup happened in #39 (which removed the GSD-baseline section from `.gitignore`). The only remaining tracked `gsd*` mentions were:
- `.gitignore` entries for `.gsd` / `.gsd-id` / `.planning/` — removed in #39.
- The untracked `.claude/` directory — gitignored.
- This single fixture string.

## Verification
`grep -rI 'gsd' -- .` returns only screenshots/animated.svg font-binary false positives (verified: 0 matches with proper grep).

This is a no-functional-change edit to demo fixture data.