### PR TITLE
chore(release): wire git-cliff into cargo-dist for auto CHANGELOG

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ publish-jobs = ["./homebrew-app-token"]
 # Pin .tar.gz (not dist's .tar.xz default) to preserve the existing release-URL
 # contract and keep the install.sh diff minimal.
 unix-archive = ".tar.gz"
+# Hand CHANGELOG regeneration to git-cliff on tag-push. cliff.toml at the
+# repo root maps conventional-commit types to Keep-a-Changelog sections.
+changelog = "git-cliff"
 ci = ["github"]
 # We pin actions to commit SHAs in release.yml for zizmor compliance,
 # which diverges from what cargo-dist generates. Accept this drift.

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,57 @@
+# git-cliff configuration for claudebar
+#
+# Wired into cargo-dist via `changelog = "git-cliff"` in
+# [workspace.metadata.dist]. We override three pieces of cliff's default
+# behavior and accept everything else — group auto-derivation with emoji
+# headings, scope-preserved commit subjects, conventional-commit
+# preprocessing — exactly as cliff ships them:
+#
+#   1. header — CalVer accuracy note (cliff's default uses the keep-a-changelog
+#      boilerplate that asserts SemVer, which we don't follow)
+#   2. body   - strip the `- YYYY-MM-DD` date suffix from each section heading
+#      because CalVer already encodes the date; cliff 2.x renders the group
+#      value as `<!-- N -->🚀 Features` (sort-index + emoji prefix), so we
+#      also strip the leading comment prefix via `split("-->" | last`
+#   3. footer — `[X.Y.Z]: compare/…` link anchors for cross-release navigation;
+#      cliff's default emits none
+#
+# Local sanity check:
+#   git cliff --unreleased
+#   git cliff --tag <calver> -o CHANGELOG.md
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions follow CalVer (`YYYY.M.PATCH`) with optional `-beta.N` pre-release suffixes;
+see `RELEASING.md` for the release ritual.
+"""
+
+body = """
+{% if version %}## [{{ version }}]
+{% else %}## [Unreleased]
+{% endif %}
+
+{% for group, commits in commits | filter(attribute="merge_commit", value=false) | unique(attribute="message") | group_by(attribute="group") %}
+### {{ group | split(pat="-->") | last | trim_start }}
+{% for commit in commits | sort(attribute="message") %}
+- {{ commit.message | split(pat="\n") | first | trim_end | upper_first }}
+{% endfor %}
+{% endfor %}
+"""
+
+footer = """
+{% for release in releases %}{% if release.previous -%}
+[{{ release.version }}]: https://github.com/micschr0/claudebar/compare/{{ release.previous.version }}...{{ release.version }}
+{% endif %}{% endfor %}
+"""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+tag_pattern = "[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z]+\\.[0-9]+)?"
+topo_order = false


### PR DESCRIPTION
Wire `git-cliff` into cargo-dist so `CHANGELOG.md` regenerates on every tag-push. Three overrides on cliff's default behavior, accept the rest.

## What's in

| File | Change |
|---|---|
| `Cargo.toml` | `changelog = "git-cliff"` flag in `[workspace.metadata.dist]` |
| `cliff.toml` | new — git-cliff config, 57 lines, minimal-default |

## cliff.toml: 3 overrides

1. **Header** — CalVer accuracy note replaces cliff's keep-a-changelog boilerplate (which falsely asserts SemVer).
2. **Body** — strips `- YYYY-MM-DD` suffix per section heading (CalVer already encodes the date). cliff 2.x renders group values as `<!-- N -->🚀 Features` (sort-index + emoji prefix); `split("-->") | last | trim_start` strips the leading comment.
3. **Footer** — `[X.Y.Z]: compare/<prev>...<next>` link anchors for cross-release navigation. cliff default emits none.

Accepted defaults:
- Group auto-derivation from conventional-commit types → emoji headings (`🚀 Features`, `📚 Documentation`, `⚙️ Miscellaneous Tasks`)
- Scope-preserved commit subjects
- Conventional-commit preprocessing + `filter_unconventional`

## Sanity

```bash
git cliff --unreleased
git cliff --tag <calver> -o CHANGELOG.md
```

## Local verification done

- `git cliff --unreleased` against this branch's HEAD: `🚀 Features: Ship prereleases to versioned @beta formula`, `📚 Documentation: Sweep unreleased entries between 2026.7.7 and HEAD`, `⚙️ Miscellaneous Tasks: Wire git-cliff into cargo-dist for auto CHANGELOG`.
- `git cliff --tag 2026.7.7`: section heading is `## [2026.7.7]` (no date), `[2026.7.20-beta.2]: ...`, `[2026.7.7]: ...` chain back to `[2026.6.24]`.
- `cargo metadata --no-deps`: parses cleanly.

## Workflow change

`RELEASING.md` § 2 ritual unchanged: bump `Cargo.toml`, commit, tag, push. cargo-dist now additionally runs `git-cliff --tag <version>` on tag-push and commits the regenerated `CHANGELOG.md` alongside the GitHub Release.

## Full rewrite accepted

On the next tag-push, cliff regenerates the entire `CHANGELOG.md` from git history — no incremental append. The hand-curated editorial polish in historic sections (`[2026.7.7]`, `[2026.7.5]`, etc.) gets replaced by the auto-derived commit-subject line. One-time fidelity loss, maintenance-burden savings ongoing. Maintainer accepted.

## Risk notes

- First cliff-driven release body is plain markdown of the new section, not hand-curated copy. Acceptable.
- **`dist generate --check`** runs the release.yml ↔ Cargo.toml sync guard (documented in `RELEASING.md` § 3). Should be run locally after merge to confirm `changelog = "git-cliff"` doesn't drift the auto-generated workflow.

## Out of scope

- CI job running `git cliff --unreleased` per PR for preview diff.
- Filtering orphan-type commits (`^video`, `^claudebar`, `^copy`, `^assets`, `^scripts`) so cliff doesn't render `### Video` / `### Claudebar` etc. sections in historic releases.
- `release-please` swap (would replace the existing `RELEASING.md` ritual entirely).