### PR TITLE
chore(renovate): tighten config, permissions, and gitAuthor

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -42,7 +42,10 @@ jobs:
           owner: "micschr0"
           repositories: "claudebar"
           permission-contents: write
+          permission-issues: write
           permission-pull_requests: write
+          # workflow updates are currently disabled in renovate.json, but include the permission so enabling github-actions manager later requires no token change.
+          permission-workflows: write
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -52,10 +55,10 @@ jobs:
           configurationFile: renovate.json
           token: ${{ steps.app-token.outputs.token }}
         env:
-          GIT_AUTHOR_NAME: micschro
-          GIT_AUTHOR_EMAIL: micschr0@mailbox.org
-          GIT_COMMITTER_NAME: micschro
-          GIT_COMMITTER_EMAIL: micschr0@mailbox.org
+          GIT_AUTHOR_NAME: micschr0
+          GIT_AUTHOR_EMAIL: 61987798+micschr0@users.noreply.github.com
+          GIT_COMMITTER_NAME: micschr0
+          GIT_COMMITTER_EMAIL: 61987798+micschr0@users.noreply.github.com
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_ONBOARDING: "false"
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:best-practices", ":semanticCommits"],
   "gitAuthor": "micschr0 <61987798+micschr0@users.noreply.github.com>",
   "prCreation": "immediate",
-  "rebaseWhen": "never",
+  "rebaseWhen": "auto",
   "labels": ["dependencies"],
   "dependencyDashboard": true,
   "configMigration": false,
@@ -40,9 +40,10 @@
       "automerge": true
     },
     {
-      "description": "Automerge non-major Cargo updates (CI is the gate)",
+      "description": "Automerge non-major Cargo updates (CI is the gate); exclude pre-1.0 (semver) and require the dependency to already exist",
       "matchManagers": ["cargo"],
       "matchUpdateTypes": ["patch", "minor"],
+      "matchCurrentVersion": "!/^0/",
       "automerge": true
     },
     {


### PR DESCRIPTION
## Goal
Apply Renovate best-practices recommendations as a single clean commit on `main`.

## Changes
- `renovate.json`
  - `rebaseWhen: "never"` → `"auto"` (autodetects `behind-base-branch` for automerge or required-current-branch repos; otherwise `conflicted`).
  - Cargo non-major automerge adds `matchCurrentVersion: "!/^0/"` to exclude pre-1.0 packages.
- `.github/workflows/renovate.yml`
  - `GIT_AUTHOR_*` / `GIT_COMMITTER_*` aligned to the `gitAuthor` GitHub noreply form (was `micschr0@mailbox.org`, silent drift from contributor attribution).
  - `actions/create-github-app-token` adds `permission-issues: write` and `permission-workflows: write` to match dashboard, labels, and any future GitHub-Actions-manager updates.

## Verification
- `jq empty renovate.json` → 0
- `actionlint .github/workflows/renovate.yml` → 0
- `renovate-config-validator renovate.json` → 0 (in CI)
- No manifest changes; `cargo check --locked --release` unaffected

## Request
Please merge via **squash** so `main` keeps a single clean commit.