### PR TITLE
chore(renovate): drop speculative workflows app permission

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -44,8 +44,6 @@ jobs:
           permission-contents: write
           permission-issues: write
           permission-pull_requests: write
-          # workflow updates are currently disabled in renovate.json, but include the permission so enabling github-actions manager later requires no token change.
-          permission-workflows: write
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Goal
Fix Renovate token 422 by removing the unused `permission-workflows: write` input.

## Why
The github-actions manager is disabled in `renovate.json` (`packageRules[].matchManagers: ["github-actions"]`), so requesting `permission-workflows: write` on the GitHub App installation is unused.

Manual trigger #29811994264 failed with `actions/create-github-app-token` returning 422 "The permissions requested are not granted to this installation." The micschr0-renovate app installation only grants `contents`, `issues`, and `pull_requests`.

## Verification
- `actionlint .github/workflows/renovate.yml` → 0
- Manual Renovate trigger should now succeed with the same three permissions the app already grants.

## Follow-up
When the github-actions manager is re-enabled, re-add `permission-workflows: write` and extend the app installation in GitHub Settings accordingly.