### PR TITLE
fix(renovate): use dash in permission-pull-requests input name

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -43,7 +43,7 @@ jobs:
           repositories: "claudebar"
           permission-contents: write
           permission-issues: write
-          permission-pull_requests: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Goal
Fix Renovate token 422 by using the correct input name `permission-pull-requests` (with dash) on `actions/create-github-app-token`.

## Why
Manual Renovate triggers #29812361743 and #29812578933 fail with 422 "The permissions requested are not granted to this installation." The GitHub App installation does grant `contents:write`, `issues:write`, and `pull_requests:write`, but the workflow used `permission-pull_requests` (underscore). The action accepts that as a warning, drops the input, and only forwards `contents` and `issues`, which is insufficient.

`actions/create-github-app-token` v2 input names use dashes (`permission-pull-requests`), not underscores.

## Verification
- `actionlint .github/workflows/renovate.yml` → 0
- Manual Renovate trigger should now succeed.