### PR TITLE
fix(renovate): revert input name to underscore form

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -43,7 +43,7 @@ jobs:
           repositories: "claudebar"
           permission-contents: write
           permission-issues: write
-          permission-pull-requests: write
+          permission-pull_requests: write
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Goal
Revert the dash form `permission-pull-requests` back to `permission-pull_requests`. The v2 action expects underscores and warns/drops the dash form.

## Why
PR #53 flipped the input to dash, but Renovate #29812831190 still 422s because the action input validator is still underscore-based and silently drops the dash form, so only `contents` and `issues` reach GitHub.

## Verification
- `actionlint .github/workflows/renovate.yml` → 0
- Manual Renovate trigger should now succeed with all three permissions granted.