### PR TITLE
chore(release): bump version to 2026.7.21-beta.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claudebar"
-version = "2026.7.21-beta.1"
+version = "2026.7.21-beta.2"
 dependencies = [
  "ansi-to-tui",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudebar"
-version = "2026.7.21-beta.1"
+version = "2026.7.21-beta.2"
 edition = "2024"
 description = "Powerline-style statusline for Claude Code, with TUI configurator and themes"
 license = "MIT"


### PR DESCRIPTION
Version bump for the next beta.

Contains since `2026.7.21-beta.1`:
- Formulary load test in the Homebrew publish job, replacing the dead path-based `brew audit`
- Package description shortened to 76 chars (Homebrew `desc` limit is 80)

This is the first release that will actually exercise the load test — it only runs on a tag.