### PR TITLE
chore(release): bump version to 2026.7.21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ tmp/
 # Local skills tooling (not part of the project)
 skills-lock.json
 .agents/skills/
+# Local AI runtime state
+.atl/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claudebar"
-version = "2026.7.21-beta.2"
+version = "2026.7.21"
 dependencies = [
  "ansi-to-tui",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudebar"
-version = "2026.7.21-beta.2"
+version = "2026.7.21"
 edition = "2024"
 description = "Powerline-style statusline for Claude Code, with TUI configurator and themes"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version 2026.7.21-beta.2 -> 2026.7.21 (stable release)
- Ignore local .atl AI runtime state in .gitignore

## Test plan
- [ ] CI green
- [ ] Merge, tag 2026.7.21, push tag to trigger release.yml