### PR TITLE
ci: drop renovate gitAuthor override so auto-rebase works

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices", ":semanticCommits"],
-  "gitAuthor": "micschr0 <61987798+micschr0@users.noreply.github.com>",
   "prCreation": "immediate",
   "rebaseWhen": "auto",
   "labels": ["dependencies"],


### PR DESCRIPTION
## What
Remove `gitAuthor` override from renovate.json.

## Why
Renovate commits as app bot `micschr0-renovate[bot]`. Override claimed `micschr0`. Author mismatch → Renovate thinks foreign edit → refuses auto-rebase ("does not recognize the last commit author"). Drop override → app recognizes own commits → auto-rebase back.

## Risk
None. Config-only, 1 line. Commits now attributed to bot (correct for GitHub App).