### PR TITLE
docs: add mise install method and per-method verification info

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ curl -fsSL https://raw.githubusercontent.com/micschr0/claudebar/main/install.sh 
 brew install micschr0/tap/claudebar && claudebar setup
 ```
 
+**mise**
+```bash
+mise use -g github:micschr0/claudebar && claudebar setup
+```
+
 Betas ship to a versioned formula so `brew upgrade` cannot silently bump stable users onto a prerelease:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -19,16 +19,19 @@
 > On macOS: `brew install --cask font-hack-nerd-font` (the font used in the screenshots).
 
 ```bash
+# verifies SHA256 · build provenance when gh is available
 curl -fsSL https://raw.githubusercontent.com/micschr0/claudebar/main/install.sh | bash
 ```
 
 **Homebrew**
 ```bash
+# verifies SHA256
 brew install micschr0/tap/claudebar && claudebar setup
 ```
 
 **mise**
 ```bash
+# verifies SHA256 · build provenance, automatically
 mise use -g github:micschr0/claudebar && claudebar setup
 ```
 
@@ -44,10 +47,12 @@ Every method checks the SHA256 of the downloaded archive. They differ in whether
 
 | Method | SHA256 | Build provenance |
 |---|---|---|
-| `mise` | yes | yes, automatic |
-| `install.sh` | yes, fatal on mismatch | yes, if `gh` is installed and authenticated |
-| Homebrew | yes | no |
-| `claudebar-installer.sh` (hosted) | yes | no |
+| `mise` | ✓ | ✓ automatic |
+| `install.sh` | ✓ fatal on mismatch | ~ needs `gh`, installed and authenticated |
+| Homebrew | ✓ | · |
+| `claudebar-installer.sh` (hosted) | ✓ | · |
+
+<sub>✓ verified, ~ conditional, · not checked</sub>
 
 `install.sh` treats a checksum mismatch as fatal but never fails the install on a provenance error — it scopes trust to `release.yml` via `gh attestation verify --signer-workflow` and warns if that check cannot complete. To verify a download by hand:
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,26 @@ Betas ship to a versioned formula so `brew upgrade` cannot silently bump stable 
 brew install micschr0/tap/claudebar-beta
 ```
 
+<details><summary>What each install method verifies</summary>
+
+Every method checks the SHA256 of the downloaded archive. They differ in whether they also verify [build provenance](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) — proof that the binary was built by this repo's `release.yml`, not just that it matches a published hash.
+
+| Method | SHA256 | Build provenance |
+|---|---|---|
+| `mise` | yes | yes, automatic |
+| `install.sh` | yes, fatal on mismatch | yes, if `gh` is installed and authenticated |
+| Homebrew | yes | no |
+| `claudebar-installer.sh` (hosted) | yes | no |
+
+`install.sh` treats a checksum mismatch as fatal but never fails the install on a provenance error — it scopes trust to `release.yml` via `gh attestation verify --signer-workflow` and warns if that check cannot complete. To verify a download by hand:
+
+```bash
+gh attestation verify claudebar-x86_64-unknown-linux-musl.tar.gz \
+  --repo micschr0/claudebar \
+  --signer-workflow micschr0/claudebar/.github/workflows/release.yml
+```
+</details>
+
 <details><summary>Review the script first</summary>
 
 ```bash


### PR DESCRIPTION
Add `mise` install. Document what each method verify.

## mise

```bash
mise use -g github:micschr0/claudebar && claudebar setup
```

No code change. Existing cargo-dist assets already work with mise `github` backend. `claudebar setup` appended like Homebrew line — mise only put binary on PATH, not wire `settings.json`.

## Verification info

All methods verify SHA256. Differ on build provenance. Was undocumented, so `install.sh` attestation check invisible.

- Short comment on each snippet, visible when copy-paste.
- Collapsed table with full breakdown plus manual `gh attestation verify` command.

| Method | SHA256 | Build provenance |
|---|---|---|
| `mise` | yes | yes, automatic |
| `install.sh` | yes, fatal on mismatch | yes, if `gh` available |
| Homebrew | yes | no |
| `claudebar-installer.sh` (hosted) | yes | no |

Markers plain Unicode (`✓` / `~` / `·`) with legend, not emoji. Word next to symbol so screen reader still work.

## Verified

Clean `MISE_DATA_DIR` against current release:

```
mise github:micschr0/claudebar@2026.7.21 [2/3] checksum claudebar-x86_64-unknown-linux-musl.tar.gz
mise github:micschr0/claudebar@2026.7.21 [2/3] ✓ GitHub artifact attestations verified
mise github:micschr0/claudebar@2026.7.21 ✓ installed
$ claudebar --version
claudebar 2026.7.21
```

- Checksum and attestation both verify. No `.mise.toml` overrides needed. mise check attestations by default (`github_attestations`) — confirmed in mise backend docs, not guessed from one run.
- Documented `gh attestation verify` command run against real release artifact, exit 0. Need `--repo` next to `--signer-workflow`, else `gh` reject it.
- Snippet comments checked with `bash -n`. `·` sit behind `#`, copy-paste safe.
- Homebrew and hosted dist installer use embedded hashes only. Normal cargo-dist behavior. Documented, not changed.

## Not included

- `jdx/mise` registry entry (would shorten to `mise use -g claudebar`). Revisit when more traction.
- `aqua` — registry backend mise prefer, but its CI matrix cover Windows. Current cargo-dist targets build no Windows. Revisit if Windows targets added.