### PR TITLE
fix(renovate): correct permission input name

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -43,7 +43,7 @@ jobs:
           repositories: "claudebar"
           permission-contents: write
           permission-issues: write
-          permission-pull_requests: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## What

`permission-pull_requests` → `permission-pull-requests` in the app-token step.

## Why

Action does not know the underscore form. Input silently ignored, token issued without PR write access. No error, step stays green.

Same fix landed in `gradle-test-shard-plugin` (PR #28), never rolled out here.

`permission-issues: write` is already present, so no change needed there.

## Verification

- `actionlint` passes.
- Post-merge: trigger workflow, confirm Renovate still reaches `result: done`.

## Breaking changes

None. CI config only.
