### PR TITLE
build(renovate): drop top-level schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,6 @@
   "dependencyDashboard": true,
   "platformAutomerge": true,
   "timezone": "Europe/Berlin",
-  "schedule": ["after 8am and before 6pm on Monday"],
   "cargo": {
     "rangeStrategy": "update-lockfile"
   },


### PR DESCRIPTION
## What

Removed top-level `schedule` from `renovate.json`.

## Why

Monday 8am-6pm window delays every update, then releases them as one burst — the exact noise a schedule is meant to prevent. Observed here: seven updates piled up in "Awaiting Schedule" while every manual run logged `Skipping branch creation as not within schedule`.

`minimumReleaseAge` plus `automerge` for minor/patch already cover the risk. Renovate's own `config:best-practices` sets no schedule.

## Untouched

- `vulnerabilityAlerts.schedule: ["at any time"]` — security updates stay immediate
- `lockFileMaintenance.schedule` — weekly lockfile refresh keeps its own window

## Verification

- `renovate-config-validator --strict` passes.

## Breaking changes

None. Renovate config only.
