### PR TITLE
ci: repin Swatinem/rust-cache to v2.9.2 to fix zizmor

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install mold linker
         run: sudo apt-get install -y mold
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
         with:
@@ -126,7 +126,7 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           key: ${{ matrix.target }}
       - name: Check release profile


### PR DESCRIPTION
## Problem

Every open PR is red on the `zizmor` check in the Security workflow, while all 18 other checks pass:

```
rust.yml:43:  action's hash pin has mismatched or missing version comment: points to commit 6323deb102c3
rust.yml:129: action's hash pin has mismatched or missing version comment: points to commit 6323deb102c3
Process completed with exit code 13
```

Upstream moved the floating `v2` tag of `Swatinem/rust-cache` to v2.9.2:

```
refs/tags/v2^{}  → 6323deb102c322ba6fcbdcafc7e3dddab59af2b6   (= v2.9.2)
pinned SHA       → e18b497796c12c097a38f9edb9d0641fb99eee32   (no tag points at it)
```

Since the check runs with `persona: pedantic` and `online-audits: true`, zizmor resolves the tag live and flags the `# v2` comment as no longer matching the pinned SHA. This is time-dependent, not PR-dependent — the last Security run on `main` (2026-08-02) was green, the PR runs on 2026-08-07 are red, and `main` would fail the same way on a re-run.

The existing `zizmor.yml` ignores for `rust.yml` (`stale-action-refs`, `superfluous-actions`) do not cover this audit.

## Change

Repin both occurrences in `.github/workflows/rust.yml` (lines 43 and 129):

```diff
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
```

The comment now names the exact version instead of the floating `v2` tag, so a future `v2` move won't break CI again. The action is still pinned by full SHA.

## Verification

- `git ls-remote https://github.com/Swatinem/rust-cache 'refs/tags/*'` confirms `6323deb1…` is the target of both `v2` and `v2.9.2`.
- `uvx zizmor@1.27.0 --persona pedantic --config zizmor.yml --no-online-audits .` → `No findings to report. Good job! (5 ignored, 8 suppressed)`. The online audits could not be run locally (no GitHub token available in this environment) — CI on this PR is the real check for those.

## Note (not addressed here)

The CI job pins `zizmor` via `version: latest` and currently resolves to v1.27.0, which is yanked on PyPI for GHSA-f42p-wjw5-97qh. Worth a separate look.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYxHPPi9q1WuoLBuiGanCv)_