### PR TITLE
fix(renovate): grant statuses permission

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -45,6 +45,7 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
           permission-workflows: write
+          permission-statuses: write
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## What
Added `permission-statuses: write` to the App token step.

## Why
Renovate needs `statuses:write` to set the stability-days check (commit status). Without it, the call fails with 403 and Renovate treats it as "repository changed" — aborting the whole run as soon as the first branch is processed. Every following branch (the remaining 4 GHA major updates) never gets touched in that run.

## Manual step required
Same as the workflows fix: "Commit statuses: Read and write" must additionally be enabled in the GitHub App settings (`/settings/apps/micschr0-renovate/permissions`) and accepted by the installation.