### PR TITLE
chore: release tooling follow-ups

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -38,11 +38,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
-      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           app-id: ${{ secrets.RENOVATE_APP_ID }}
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
+      - uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
         with:
           tool: git-cliff
 
@@ -124,11 +124,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
-      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           app-id: ${{ secrets.RENOVATE_APP_ID }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,6 +26,25 @@ jobs:
       - name: Run shellcheck
         run: shellcheck -S warning install.sh statusline-command.sh scripts/*.sh
 
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    container:
+      # Bundles shellcheck + pyflakes, so `run:` blocks get linted too.
+      # `--user root`: the image runs as `guest`, which cannot write the workspace.
+      image: rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+      options: --user root
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Lint workflows
+        # Same severity floor as the ShellCheck job, so `run:` blocks are held
+        # to one standard instead of two.
+        env:
+          SHELLCHECK_OPTS: -S warning
+        run: actionlint -color .github/workflows/*.yml
+
   bats:
     name: Bats
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -39,7 +39,8 @@ jobs:
 
           # Strip cargo/rustc from PATH so a broken prebuilt download (Tier 1)
           # can't be silently masked by falling through to `cargo build` (Tier 2).
-          export PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v '\.cargo/bin' | tr '\n' ':' | sed 's/:$//')
+          stripped_path=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v '\.cargo/bin' | tr '\n' ':' | sed 's/:$//') || true
+          export PATH="$stripped_path"
           if command -v cargo >/dev/null 2>&1; then
             echo "cargo still on PATH: $(command -v cargo) — PATH stripping failed" >&2
             exit 1
@@ -84,7 +85,8 @@ jobs:
 
           # Strip cargo/rustc from PATH so a broken prebuilt download (Tier 1)
           # can't be silently masked by falling through to `cargo build` (Tier 2).
-          export PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v '\.cargo/bin' | tr '\n' ':' | sed 's/:$//')
+          stripped_path=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v '\.cargo/bin' | tr '\n' ':' | sed 's/:$//') || true
+          export PATH="$stripped_path"
           if command -v cargo >/dev/null 2>&1; then
             echo "cargo still on PATH: $(command -v cargo) — PATH stripping failed" >&2
             exit 1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -81,6 +81,17 @@ tasks:
     desc: Regenerate the GitHub social-preview card (Pillow only)
     cmd: python3 scripts/gen_social_preview.py
 
+  release:
+    desc: "Open a release PR; defaults to today's CalVer: task release [-- 2026.8.20]"
+    cmd: gh workflow run release-prep.yml {{if .CLI_ARGS}}-f version='{{.CLI_ARGS}}'{{end}}
+
+  release-beta:
+    desc: "Open a prerelease PR: task release-beta -- 2026.8.20-beta.1"
+    # -beta.N is not derivable: release.yml prunes every prerelease tag but the newest.
+    cmd: |
+      [ -n "{{.CLI_ARGS}}" ] || { echo 'usage: task release-beta -- 2026.8.20-beta.1' >&2; exit 1; }
+      gh workflow run release-prep.yml -f version='{{.CLI_ARGS}}'
+
   install:
     desc: Install claudebar into ~/.claude
     cmd: bash install.sh


### PR DESCRIPTION
Follow-ups from the Renovate merge round (#78–#82).

## `build(task)` — release tasks

`task release [-- 2026.8.20]` and `task release-beta -- 2026.8.20-beta.1` wrap
`gh workflow run release-prep.yml`. `release-beta` requires an explicit version and exits 1
with a usage line otherwise, since `-beta.N` is not derivable — `release.yml` prunes every
prerelease tag but the newest.

CalVer format itself is still validated only in the workflow; no duplicate check locally.

## `ci(release-prep)` — action pins

`release-prep.yml` landed after the Renovate PRs were opened, so it kept three pre-merge pins.
Aligned with the SHAs already on `main`:

| Action | Was | Now |
|---|---|---|
| `step-security/harden-runner` | v2.19.4 | v2.20.1 |
| `actions/create-github-app-token` | v2 | v3 |
| `taiki-e/install-action` | v2.82.9 | v2.85.11 |

Every SHA verified against `repos/<repo>/git/ref/tags/<tag>`. `actionlint` clean.

## Not included

Pinning `github-custom-runners.global = "ubuntu-24.04"` turned out to be unnecessary:
`allow-dirty = ["ci"]` means dist never rewrites `release.yml`, so nothing can revert #81.
Verified locally with cargo-dist 0.32.0 — `dist generate` is a no-op on this repo.