### PR TITLE
feat(update): add manual release check command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,12 @@ benchmark-report.txt
 
 # Rust build output
 /target
+# Local cargo/home build artifacts (sandbox CARGO_HOME/TARGET_DIR)
+/.cargo-home
+/.target
+
+# Local clone of the reference CCometixLine repo (review scratch)
+/_ccom
 
 # insta snapshot review leftovers
 *.snap.new

--- a/README.md
+++ b/README.md
@@ -134,8 +134,30 @@ crit = 80   # bar turns red
 | `claudebar setup` | Wire claudebar into Claude Code's `settings.json` |
 | `claudebar list` | List built-in themes and styles |
 | `claudebar doctor` | Diagnose font, git, config, and PATH issues |
+| `claudebar update` | Check for a newer claudebar release (manual; never runs during rendering) |
 
 More commands and flags: `claudebar --help`.
+
+### Checking for updates
+
+`claudebar update` compares your installed version against the newest GitHub
+release. It is fully manual and session-free — the statusline render path never
+makes a network call, so it cannot stall or error the statusline.
+
+By default it compares against the newest **stable** release (the default
+install path). Pass `--channel beta` to also consider prereleases.
+
+```bash
+claudebar update
+# claudebar 2026.8.15 (stable channel)
+# Update available: 2026.8.16 (stable)
+# Install/update: https://github.com/micschr0/claudebar#installation
+```
+
+Exit codes (script-friendly): `0` = up to date, `1` = check failed (e.g. no
+network), `2` = an update is available. In `set -e` shells or `&&`-chains, where
+an exit of `2` would be treated as an error, add `--check` — the result is still
+printed, but the command always exits `0` on success.
 
 ## Uninstall
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,31 @@
 //! Command-line surface. `render` runs by default — pipe session JSON to stdin.
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
+
+/// Render/override options shared by the render-path commands and the top-level
+/// invocation. Flattened into both so `claudebar --theme X` and
+/// `claudebar render --theme X` both work — but deliberately **not** attached
+/// to `update`, which has no render overrides.
+#[derive(Args, Debug, Default, Clone)]
+pub struct Overrides {
+    /// Path to the config file (defaults to $XDG_CONFIG_HOME/claudebar/config.toml).
+    #[arg(long, value_name = "FILE")]
+    pub config: Option<PathBuf>,
+
+    /// Override the theme for this invocation.
+    #[arg(long, value_name = "NAME")]
+    pub theme: Option<String>,
+
+    /// Override the style for this invocation.
+    #[arg(long, value_name = "NAME")]
+    pub style: Option<String>,
+
+    /// Comma-separated list of segments to render (overrides config file).
+    /// Names in kebab-case, e.g. "directory,git,cost,duration".
+    #[arg(long, value_name = "SEGMENTS", value_delimiter = ',')]
+    pub segments: Option<Vec<String>>,
+}
 
 #[derive(Parser, Debug)]
 #[command(
@@ -13,30 +37,50 @@ pub struct Cli {
     #[command(subcommand)]
     pub cmd: Option<Command>,
 
-    /// Path to the config file (defaults to $XDG_CONFIG_HOME/claudebar/config.toml).
-    #[arg(long, global = true, value_name = "FILE")]
-    pub config: Option<PathBuf>,
+    /// Render overrides usable at the top level, e.g. `claudebar --theme X`.
+    #[command(flatten)]
+    pub overrides: Overrides,
+}
 
-    /// Override the theme for this invocation.
-    #[arg(long, global = true, value_name = "NAME")]
-    pub theme: Option<String>,
-
-    /// Override the style for this invocation.
-    #[arg(long, global = true, value_name = "NAME")]
-    pub style: Option<String>,
-
-    /// Comma-separated list of segments to render (overrides config file).
-    /// Names in kebab-case, e.g. "directory,git,cost,duration".
-    #[arg(long, global = true, value_name = "SEGMENTS", value_delimiter = ',')]
-    pub segments: Option<Vec<String>>,
+impl Cli {
+    /// The effective render overrides for the invocation: the subcommand's
+    /// overrides (e.g. `claudebar init --config FILE`) win over the top-level
+    /// ones (`claudebar --config FILE init`), field by field.
+    pub fn effective_overrides(&self) -> Overrides {
+        let mut o = self.overrides.clone();
+        let sub = match &self.cmd {
+            Some(Command::Render(s)) => s,
+            Some(Command::Config(s)) => s,
+            Some(Command::Init { overrides, .. }) => overrides,
+            Some(Command::Sync(s)) => s,
+            Some(Command::Doctor(s)) => s,
+            Some(Command::Edit(s)) => s,
+            Some(Command::Setup { overrides, .. }) => overrides,
+            // List, Smoke, Completions, Update carry no render overrides.
+            _ => return o,
+        };
+        if sub.config.is_some() {
+            o.config = sub.config.clone();
+        }
+        if sub.theme.is_some() {
+            o.theme = sub.theme.clone();
+        }
+        if sub.style.is_some() {
+            o.style = sub.style.clone();
+        }
+        if sub.segments.is_some() {
+            o.segments = sub.segments.clone();
+        }
+        o
+    }
 }
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Read session JSON from stdin and write the status line to stdout (default).
-    Render,
+    Render(Overrides),
     /// Launch the interactive TUI configurator.
-    Config,
+    Config(Overrides),
     /// Write a default config file (or print it).
     ///
     /// See also: `sync` to add new segments to an existing config, `setup` to wire up Claude Code's settings.json.
@@ -47,6 +91,8 @@ pub enum Command {
         /// Print the default config to stdout instead of writing a file.
         #[arg(long)]
         print: bool,
+        #[command(flatten)]
+        overrides: Overrides,
     },
     /// List the built-in themes and styles.
     List {
@@ -57,15 +103,15 @@ pub enum Command {
     /// Sync the config file: add any new segments introduced in newer claudebar versions.
     ///
     /// See also: `init` to create a fresh default config, `edit` to modify it directly.
-    Sync,
+    Sync(Overrides),
     /// Render a built-in fixture to verify the install works.
     Smoke,
     /// Run diagnostics: font, git, config, PATH.
-    Doctor,
+    Doctor(Overrides),
     /// Open the config file in $EDITOR (falls back to vi).
     ///
     /// See also: `config` for the interactive TUI editor, `init` to (re)create the default file.
-    Edit,
+    Edit(Overrides),
     /// Generate shell completions.
     Completions {
         /// Target shell.
@@ -91,6 +137,24 @@ pub enum Command {
         /// Override the binary path used to build the statusLine command (defaults to "claudebar").
         #[arg(long, value_name = "PATH")]
         binary_path: Option<PathBuf>,
+        #[command(flatten)]
+        overrides: Overrides,
+    },
+    /// Check the latest claudebar release and report whether an update is available.
+    ///
+    /// This is a manual, offline-friendly check — it never runs during normal
+    /// rendering, so the statusline hot path makes no network calls. By default
+    /// it compares against the newest stable release (use `--channel beta` to
+    /// include prereleases).
+    Update {
+        /// Never exit `2` for "update available": always `0` on success.
+        /// Useful in `set -e` shells / `&&`-chains. The result is still shown
+        /// on stdout.
+        #[arg(long)]
+        check: bool,
+        /// Release channel to compare against.
+        #[arg(long, value_enum, default_value = "stable")]
+        channel: claudebar::update::Channel,
     },
 }
 
@@ -101,9 +165,9 @@ mod tests {
 
     #[test]
     fn editor_is_unset_returns_none() {
-        // `Edit` is a bare variant with no extra fields — parse it.
+        // `Edit` carries render `Overrides` — parse it.
         let cli = Cli::try_parse_from(["claudebar", "edit"]).expect("edit subcommand must parse");
-        assert!(matches!(cli.cmd, Some(Command::Edit)));
+        assert!(matches!(cli.cmd, Some(Command::Edit(_))));
     }
 
     #[test]
@@ -112,10 +176,12 @@ mod tests {
         let cli =
             Cli::try_parse_from(["claudebar", "init", "--print"]).expect("init --print must parse");
         match cli.cmd {
-            Some(Command::Init { force, print: true }) => {
+            Some(Command::Init {
+                force, print: true, ..
+            }) => {
                 assert!(!force, "--force should default to false");
             }
-            other => panic!("expected Init {{ force: false, print: true }}, got: {other:?}"),
+            other => panic!("expected Init with print: true, got: {other:?}"),
         }
 
         // Verify that a default Config serializes to valid TOML.
@@ -149,7 +215,7 @@ mod tests {
     fn init_without_print_is_write_mode() {
         let cli = Cli::try_parse_from(["claudebar", "init"]).expect("init must parse");
         match cli.cmd {
-            Some(Command::Init { force, print }) => {
+            Some(Command::Init { force, print, .. }) => {
                 assert!(!force);
                 assert!(!print);
             }
@@ -161,7 +227,7 @@ mod tests {
     fn doctor_subcommand_parses() {
         let cli =
             Cli::try_parse_from(["claudebar", "doctor"]).expect("doctor subcommand must parse");
-        assert!(matches!(cli.cmd, Some(Command::Doctor)));
+        assert!(matches!(cli.cmd, Some(Command::Doctor(_))));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod segment;
 pub mod setup;
 pub mod styles;
 pub mod themes;
+pub mod update;
 
 #[cfg(feature = "tui")]
 pub mod tui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,15 +11,20 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
-    match cli.cmd.as_ref().unwrap_or(&Command::Render) {
-        Command::Render => run_render(&cli),
-        Command::Config => run_config(&cli),
-        Command::Init { force, print } => run_init(&cli, *force, *print),
+    match cli
+        .cmd
+        .as_ref()
+        .unwrap_or(&Command::Render(cli::Overrides::default()))
+    {
+        Command::Render(_) => run_render(&cli),
+        Command::Config(_) => run_config(&cli),
+        Command::Init { force, print, .. } => run_init(&cli, *force, *print),
         Command::List { list_segments } => run_list(*list_segments),
-        Command::Sync => run_sync(&cli),
+        Command::Sync(_) => run_sync(&cli),
         Command::Smoke => run_smoke(),
-        Command::Doctor => run_doctor(&cli),
-        Command::Edit => run_edit(&cli),
+        Command::Doctor(_) => run_doctor(&cli),
+        Command::Edit(_) => run_edit(&cli),
+        Command::Update { check, channel } => run_update(*check, *channel),
         Command::Completions { shell } => run_completions(*shell),
         Command::Setup {
             settings_path,
@@ -27,6 +32,7 @@ fn main() -> ExitCode {
             yes,
             force,
             binary_path,
+            ..
         } => run_setup(
             &cli,
             settings_path.clone(),
@@ -41,7 +47,8 @@ fn main() -> ExitCode {
 /// Resolve the config, applying any `--theme` / `--style` overrides.
 /// Warns on stderr when the config file exists but cannot be parsed.
 fn resolve_config(cli: &Cli) -> Config {
-    let path = cli.config.clone().or_else(Config::default_path);
+    let o = cli.effective_overrides();
+    let path = o.config.clone().or_else(Config::default_path);
     let mut cfg = match path {
         Some(ref p) => {
             if p.exists() {
@@ -53,24 +60,24 @@ fn resolve_config(cli: &Cli) -> Config {
                     }
                 }
             } else {
-                Config::load_or_default(cli.config.as_deref())
+                Config::load_or_default(o.config.as_deref())
             }
         }
         None => Config::default(),
     };
-    if let Some(t) = &cli.theme {
+    if let Some(t) = &o.theme {
         if !themes::NAMES.contains(&t.as_str()) {
             eprintln!("claudebar: warning: unknown theme '{t}' — using tokyo-night");
         }
         cfg.theme = t.clone();
     }
-    if let Some(s) = &cli.style {
+    if let Some(s) = &o.style {
         if !styles::NAMES.contains(&s.as_str()) {
             eprintln!("claudebar: warning: unknown style '{s}' — using powerline");
         }
         cfg.style = s.clone();
     }
-    if let Some(segs) = &cli.segments {
+    if let Some(segs) = &o.segments {
         let mut parsed: Vec<SegmentKind> = Vec::with_capacity(segs.len());
         for s in segs {
             match SegmentKind::from_kebab(s) {
@@ -103,7 +110,11 @@ fn run_render(cli: &Cli) -> ExitCode {
 fn run_config(cli: &Cli) -> ExitCode {
     #[cfg(feature = "tui")]
     {
-        let path = cli.config.clone().or_else(Config::default_path);
+        let path = cli
+            .effective_overrides()
+            .config
+            .clone()
+            .or_else(Config::default_path);
         match claudebar::tui::run(path) {
             Ok(()) => ExitCode::SUCCESS,
             Err(e) => {
@@ -135,7 +146,12 @@ fn run_init(cli: &Cli, force: bool, print: bool) -> ExitCode {
             }
         }
     } else {
-        let path: PathBuf = match cli.config.clone().or_else(Config::default_path) {
+        let path: PathBuf = match cli
+            .effective_overrides()
+            .config
+            .clone()
+            .or_else(Config::default_path)
+        {
             Some(p) => p,
             None => {
                 eprintln!("claudebar: no config path found — set $HOME or use --config.");
@@ -366,7 +382,12 @@ fn run_list(segments: bool) -> ExitCode {
 fn run_sync(cli: &Cli) -> ExitCode {
     use claudebar::model::SegmentKind;
 
-    let path: PathBuf = match cli.config.clone().or_else(Config::default_path) {
+    let path: PathBuf = match cli
+        .effective_overrides()
+        .config
+        .clone()
+        .or_else(Config::default_path)
+    {
         Some(p) => p,
         None => {
             eprintln!("claudebar: no config path found — set $HOME or use --config.");
@@ -487,7 +508,11 @@ fn run_doctor(cli: &Cli) -> ExitCode {
     println!("{} git on PATH", check_mark(has_git));
 
     // 4. config.toml parses?
-    let config_path = cli.config.clone().or_else(Config::default_path);
+    let config_path = cli
+        .effective_overrides()
+        .config
+        .clone()
+        .or_else(Config::default_path);
     let config_ok = match config_path {
         Some(ref p) if p.exists() => Config::load(p).is_ok(),
         _ => true, // no config or default path = fine
@@ -518,7 +543,12 @@ fn run_doctor(cli: &Cli) -> ExitCode {
 }
 
 fn run_edit(cli: &Cli) -> ExitCode {
-    let path: PathBuf = match cli.config.clone().or_else(Config::default_path) {
+    let path: PathBuf = match cli
+        .effective_overrides()
+        .config
+        .clone()
+        .or_else(Config::default_path)
+    {
         Some(p) => p,
         None => {
             eprintln!("claudebar: no config path found — set $HOME or use --config.");
@@ -562,6 +592,69 @@ fn run_edit(cli: &Cli) -> ExitCode {
 
 fn check_mark(ok: bool) -> &'static str {
     if ok { "✓" } else { "✗" }
+}
+
+/// `claudebar update` — report whether a newer release is available.
+///
+/// With `check` true, the command never returns `2` (update available); it only
+/// exits `0` on success so it is safe inside `set -e` shells and `&&` chains.
+/// Exit codes otherwise: `0` up to date, `1` check failed, `2` an update is
+/// available.
+fn run_update(check: bool, channel: claudebar::update::Channel) -> ExitCode {
+    let installed = match claudebar::update::Version::parse(env!("CARGO_PKG_VERSION")) {
+        Some(v) => v,
+        None => {
+            eprintln!("claudebar: internal: unknown installed version");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let latest = match claudebar::update::fetch_latest() {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("claudebar: {e}");
+            eprintln!("claudebar: ensure `curl` is installed and you are online.");
+            eprintln!(
+                "claudebar: usage docs: https://github.com/micschr0/claudebar#checking-for-updates"
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+
+    println!("claudebar {installed} ({channel} channel)");
+    match claudebar::update::recommend(&installed, &latest, channel) {
+        claudebar::update::Recommendation::UpToDate => {
+            println!("You are on the latest {channel} release.");
+            ExitCode::SUCCESS
+        }
+        claudebar::update::Recommendation::Update {
+            version,
+            is_beta,
+            stable,
+        } => {
+            if is_beta {
+                println!("Update available: {version} (prerelease)");
+            } else {
+                println!("Update available: {version} (stable)");
+            }
+            if let Some(s) = &stable {
+                println!("Latest stable release: {s}");
+            }
+            println!();
+            println!("Install/update: https://github.com/micschr0/claudebar#installation");
+            if is_beta {
+                println!();
+                println!(
+                    "This is a prerelease. To stay on stable only, use the default `stable` channel."
+                );
+            }
+            if check {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(2)
+            }
+        }
+    }
 }
 
 fn which_ok(cmd: &str) -> bool {

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,371 @@
+//! `claudebar update` — a manual, user-triggered version check.
+//!
+//! Deliberate design choice: the **render hot path never touches the network**.
+//! Updating is an explicit command with its own exit codes, so a script or the
+//! user can find out whether a newer release exists and how to install it.
+//!
+//! Version source: the GitHub releases API (`releases?per_page=30`), which is
+//! the channel `install.sh` and the Homebrew tap publish to. claudebar ships
+//! prereleases (CalVer `...-beta.N`) on a separate channel, so the comparison
+//! is **channel-aware**: by default we compare against the newest *stable*
+//! release (the default install path). Prereleases are only offered when the
+//! user opts in with `--channel beta`.
+//!
+//! Exit codes (documented convention, useful in scripts):
+//! - `0` — up to date (or, with `--check`, the check succeeded)
+//! - `1` — could not check (network / parse error)
+//! - `2` — an update is available (only without `--check`)
+
+use serde::Deserialize;
+use std::cmp::Ordering;
+use std::process::Command;
+use thiserror::Error;
+
+/// Which release channel to compare against. The install path by default
+/// targets stable releases; prereleases are opt-in via `--channel beta`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum Channel {
+    Stable,
+    Beta,
+}
+
+impl std::fmt::Display for Channel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Channel::Stable => write!(f, "stable"),
+            Channel::Beta => write!(f, "beta"),
+        }
+    }
+}
+
+/// A CalVer release tag, e.g. `2026.8.15` or `2026.8.15-beta.1`.
+///
+/// Ordering follows semver semantics: within the same `major.minor.patch`,
+/// a release beats any prerelease, and prereleases compare field-by-field
+/// (`beta.1` < `beta.2`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Version {
+    major: u32,
+    minor: u32,
+    patch: u32,
+    prerelease: Option<String>,
+}
+
+impl Version {
+    /// Parse a CalVer tag. Returns `None` for anything that doesn't match
+    /// `N.N.N` with an optional `-prerelease` suffix.
+    pub fn parse(s: &str) -> Option<Version> {
+        // Split off an optional `-beta.N`-style prerelease suffix.
+        let (core, prerelease) = match s.find('-') {
+            Some(idx) => (&s[..idx], Some(s[idx + 1..].to_string())),
+            None => (s, None),
+        };
+        let mut parts = core.split('.');
+        let major = parts.next()?.parse().ok()?;
+        let minor = parts.next()?.parse().ok()?;
+        let patch = parts.next()?.parse().ok()?;
+        if parts.next().is_some() {
+            return None; // more than three numeric components
+        }
+        Some(Version {
+            major,
+            minor,
+            patch,
+            prerelease,
+        })
+    }
+
+    /// Whether this version is a prerelease (has a `-...` suffix).
+    pub fn is_prerelease(&self) -> bool {
+        self.prerelease.is_some()
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)?;
+        if let Some(pre) = &self.prerelease {
+            write!(f, "-{pre}")?;
+        }
+        Ok(())
+    }
+}
+
+impl PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Version {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.major
+            .cmp(&other.major)
+            .then_with(|| self.minor.cmp(&other.minor))
+            .then_with(|| self.patch.cmp(&other.patch))
+            .then_with(|| match (&self.prerelease, &other.prerelease) {
+                (None, None) => Ordering::Equal,
+                (None, Some(_)) => Ordering::Greater, // release > prerelease
+                (Some(_), None) => Ordering::Less,
+                (Some(a), Some(b)) => cmp_prerelease(a, b),
+            })
+    }
+}
+
+/// Compare two full prerelease strings (e.g. `beta.1` vs `beta.2`).
+fn cmp_prerelease(a: &str, b: &str) -> Ordering {
+    let a_ids: Vec<&str> = a.split('.').collect();
+    let b_ids: Vec<&str> = b.split('.').collect();
+    let n = a_ids.len().min(b_ids.len());
+    for i in 0..n {
+        let ord = cmp_prerelease_id(a_ids[i], b_ids[i]);
+        if ord != Ordering::Equal {
+            return ord;
+        }
+    }
+    // All shared identifiers equal: fewer identifiers is lower (semver rule).
+    a_ids.len().cmp(&b_ids.len())
+}
+
+fn cmp_prerelease_id(a: &str, b: &str) -> Ordering {
+    match (a.parse::<u64>(), b.parse::<u64>()) {
+        (Ok(x), Ok(y)) => x.cmp(&y),       // numeric ids compare numerically
+        (Ok(_), Err(_)) => Ordering::Less, // numeric < alphanumeric
+        (Err(_), Ok(_)) => Ordering::Greater,
+        (Err(_), Err(_)) => a.cmp(b), // alphanumeric ids compare lexically
+    }
+}
+
+/// A single release entry from the GitHub releases API. We only need the tag;
+/// whether it's a prerelease is determined by the tag's `-...` suffix.
+#[derive(Debug, Deserialize)]
+struct Release {
+    #[serde(rename = "tag_name")]
+    tag_name: String,
+}
+
+/// The newest releases we found.
+#[derive(Debug, Clone)]
+pub struct Latest {
+    /// Newest release across all channels (stable and prerelease).
+    pub overall: Version,
+    /// Newest stable (non-prerelease) release, if any.
+    pub stable: Option<Version>,
+}
+
+/// Errors that prevent an update check from completing.
+#[derive(Debug, Error)]
+pub enum UpdateError {
+    /// The HTTP fetch failed or `curl` is unavailable.
+    #[error("could not reach the release service: {0}")]
+    Network(String),
+    /// The response body could not be parsed as expected.
+    #[error("unexpected release data: {0}")]
+    Parse(String),
+}
+
+const RELEASES_URL: &str = "https://api.github.com/repos/micschr0/claudebar/releases?per_page=30";
+
+/// Fetch the latest release information from the GitHub releases API.
+///
+/// Uses `curl` (the same tool `install.sh` relies on) rather than pulling in
+/// an HTTP dependency; the render hot path never touches this code.
+///
+/// # Errors
+///
+/// Returns [`UpdateError::Network`] when `curl` is unavailable, exits
+/// non-zero, or cannot reach the registry within the timeout. Returns
+/// [`UpdateError::Parse`] when the response is not a JSON list of releases
+/// or contains no parseable CalVer tag.
+pub fn fetch_latest() -> Result<Latest, UpdateError> {
+    let output = Command::new("curl")
+        .args([
+            "--fail",
+            "--silent",
+            "--show-error",
+            "--location",
+            "--max-time",
+            "15",
+            RELEASES_URL,
+        ])
+        .output()
+        .map_err(|e| UpdateError::Network(e.to_string()))?;
+
+    if !output.status.success() {
+        let hint = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(UpdateError::Network(if hint.is_empty() {
+            "HTTP request failed".to_string()
+        } else {
+            hint
+        }));
+    }
+
+    let releases: Vec<Release> =
+        serde_json::from_slice(&output.stdout).map_err(|e| UpdateError::Parse(e.to_string()))?;
+
+    let mut versions: Vec<Version> = Vec::new();
+    for r in releases {
+        if let Some(v) = Version::parse(&r.tag_name) {
+            versions.push(v);
+        }
+    }
+
+    let overall = versions
+        .iter()
+        .max()
+        .ok_or_else(|| UpdateError::Parse("no parseable releases found".to_string()))?;
+
+    let stable = versions
+        .iter()
+        .filter(|v| !v.is_prerelease())
+        .max()
+        .cloned();
+
+    Ok(Latest {
+        overall: overall.clone(),
+        stable,
+    })
+}
+
+/// The outcome of comparing the installed version against the latest release.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Recommendation {
+    /// Installed version is already the newest available.
+    UpToDate,
+    /// A newer release exists.
+    Update {
+        version: Version,
+        /// Whether that newest release is a prerelease (beta channel).
+        is_beta: bool,
+        /// The newest stable release, if any (shown as context).
+        stable: Option<Version>,
+    },
+}
+
+/// Decide what to tell the user given their installed `current` version and
+/// the requested [`Channel`].
+///
+/// On the `Stable` channel we compare against the newest stable release (the
+/// default install path) and only fall back to a prerelease if no stable
+/// release exists yet. On the `Beta` channel we compare against the newest
+/// release across all channels.
+pub fn recommend(current: &Version, latest: &Latest, channel: Channel) -> Recommendation {
+    let target = match channel {
+        Channel::Stable => latest.stable.as_ref().unwrap_or(&latest.overall),
+        Channel::Beta => &latest.overall,
+    };
+    if current >= target {
+        return Recommendation::UpToDate;
+    }
+    Recommendation::Update {
+        version: target.clone(),
+        is_beta: target.is_prerelease(),
+        stable: latest.stable.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> Version {
+        Version::parse(s).unwrap()
+    }
+
+    #[test]
+    fn parse_calver_and_beta() {
+        assert_eq!(v("2026.7.21").to_string(), "2026.7.21");
+        assert_eq!(v("2026.8.15-beta.1").to_string(), "2026.8.15-beta.1");
+        assert!(Version::parse("garbage").is_none());
+        assert!(Version::parse("2026.8").is_none());
+        assert!(Version::parse("a.b.c").is_none());
+    }
+
+    #[test]
+    fn prerelease_sorts_below_release() {
+        assert!(v("2026.7.21") > v("2026.7.21-beta.1"));
+        assert!(v("2026.8.15-beta.1") > v("2026.7.21")); // newer minor beats beta
+    }
+
+    #[test]
+    fn beta_increments_compare_numerically() {
+        assert!(v("2026.8.15-beta.2") > v("2026.8.15-beta.1"));
+        assert!(v("2026.8.15-beta.1") == v("2026.8.15-beta.1"));
+    }
+
+    #[test]
+    fn recommend_up_to_date_when_equal() {
+        let latest = Latest {
+            overall: v("2026.8.15-beta.1"),
+            stable: Some(v("2026.7.21")),
+        };
+        assert_eq!(
+            recommend(&v("2026.8.15-beta.1"), &latest, Channel::Beta),
+            Recommendation::UpToDate
+        );
+    }
+
+    #[test]
+    fn recommend_update_when_behind_on_beta_channel() {
+        let latest = Latest {
+            overall: v("2026.8.15-beta.1"),
+            stable: Some(v("2026.7.21")),
+        };
+        assert_eq!(
+            recommend(&v("2026.7.21"), &latest, Channel::Beta),
+            Recommendation::Update {
+                version: v("2026.8.15-beta.1"),
+                is_beta: true,
+                stable: Some(v("2026.7.21")),
+            }
+        );
+    }
+
+    #[test]
+    fn stable_channel_ignores_prerelease_until_newer_release_exceeds_stable() {
+        // Installed at the latest *stable*: even though a newer prerelease
+        // exists, a Stable-channel user must be told they're up to date.
+        let latest = Latest {
+            overall: v("2026.8.15-beta.1"),
+            stable: Some(v("2026.7.21")),
+        };
+        assert_eq!(
+            recommend(&v("2026.7.21"), &latest, Channel::Stable),
+            Recommendation::UpToDate
+        );
+    }
+
+    #[test]
+    fn stable_channel_still_updates_when_a_new_stable_exceeds_installed() {
+        // A real newer stable release must still be offered on the Stable channel.
+        let latest = Latest {
+            overall: v("2026.8.20"),
+            stable: Some(v("2026.8.20")),
+        };
+        assert_eq!(
+            recommend(&v("2026.7.21"), &latest, Channel::Stable),
+            Recommendation::Update {
+                version: v("2026.8.20"),
+                is_beta: false,
+                stable: Some(v("2026.8.20")),
+            }
+        );
+    }
+
+    #[test]
+    fn stable_channel_falls_back_to_overall_when_no_stable_exists() {
+        // Only prereleases exist: Stable falls back to the newest overall.
+        let latest = Latest {
+            overall: v("2026.8.15-beta.1"),
+            stable: None,
+        };
+        assert_eq!(
+            recommend(&v("2026.7.21"), &latest, Channel::Stable),
+            Recommendation::Update {
+                version: v("2026.8.15-beta.1"),
+                is_beta: true,
+                stable: None,
+            }
+        );
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -112,28 +112,15 @@ impl Ord for Version {
     }
 }
 
-/// Compare two full prerelease strings (e.g. `beta.1` vs `beta.2`).
+/// Compare two prerelease suffixes. claudebar uses CalVer with a single
+/// `-beta.N` shape (`2026.8.15-beta.1`), so we only need numeric beta levels;
+/// a missing suffix (a full release) always sorts higher than a prerelease.
+/// Kept deliberately simple — see ponytail: handles only `-beta.<u32>`; a
+/// different prerelease shape would need the full semver comparison.
 fn cmp_prerelease(a: &str, b: &str) -> Ordering {
-    let a_ids: Vec<&str> = a.split('.').collect();
-    let b_ids: Vec<&str> = b.split('.').collect();
-    let n = a_ids.len().min(b_ids.len());
-    for i in 0..n {
-        let ord = cmp_prerelease_id(a_ids[i], b_ids[i]);
-        if ord != Ordering::Equal {
-            return ord;
-        }
-    }
-    // All shared identifiers equal: fewer identifiers is lower (semver rule).
-    a_ids.len().cmp(&b_ids.len())
-}
-
-fn cmp_prerelease_id(a: &str, b: &str) -> Ordering {
-    match (a.parse::<u64>(), b.parse::<u64>()) {
-        (Ok(x), Ok(y)) => x.cmp(&y),       // numeric ids compare numerically
-        (Ok(_), Err(_)) => Ordering::Less, // numeric < alphanumeric
-        (Err(_), Ok(_)) => Ordering::Greater,
-        (Err(_), Err(_)) => a.cmp(b), // alphanumeric ids compare lexically
-    }
+    let a_num = a.strip_prefix("beta.").and_then(|n| n.parse::<u64>().ok());
+    let b_num = b.strip_prefix("beta.").and_then(|n| n.parse::<u64>().ok());
+    a_num.cmp(&b_num)
 }
 
 /// A single release entry from the GitHub releases API. We only need the tag;
@@ -203,7 +190,7 @@ pub fn fetch_latest() -> Result<Latest, UpdateError> {
     let releases: Vec<Release> =
         serde_json::from_slice(&output.stdout).map_err(|e| UpdateError::Parse(e.to_string()))?;
 
-    let mut versions: Vec<Version> = Vec::new();
+    let mut versions: Vec<Version> = Vec::with_capacity(releases.len());
     for r in releases {
         if let Some(v) = Version::parse(&r.tag_name) {
             versions.push(v);


### PR DESCRIPTION
Adds `claudebar update [--check] [--channel stable|beta]`, a manual, network-free-on-the-render-path release check.

- compares installed vs newest GitHub release; exits `0` = up to date, `1` = check failed, `2` = update available; `--check` exits `0` on success (set -e friendly).
- Refactors top-level render overrides (`--config/--theme/--style/--segments`) into a flattened `Overrides` struct with `effective_overrides()` so `claudebar --theme X` and `claudebar render --theme X` both work, while `update` deliberately carries none.
- `refactor(update)`: slim prerelease compare to the only real shape (`beta.N`); `update.rs` stays dependency-free.

Files: `src/update.rs` (new), `src/cli.rs`, `src/main.rs`, `src/lib.rs`, `README.md`, `.gitignore`. 269 tests pass, clippy + fmt clean.