### PR TITLE
chore(release): drop the cargo-dist hosted shell installer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,9 @@ targets = [
 # the same job into the @beta branch (release.yml's custom-homebrew-app-token
 # job). Without this flag, that job's `if:` short-circuits prereleases.
 publish-prereleases = true
-# Hosted shell installer (curl | sh) as a binary-only alternative to install.sh.
-installers = ["shell", "homebrew"]
+# Homebrew is the only cargo-dist-built installer; install.sh (repo root) is
+# the documented curl | sh path and is not built here.
+installers = ["homebrew"]
 # Bundle the binary plus auto-detected README + LICENSE (both at repo root).
 auto-includes = true
 # SHA256, sha256sum-compatible output.

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Every method checks the SHA256 of the downloaded archive. They differ in whether
 
 | Method | SHA256 | Build provenance |
 |---|---|---|
-| `mise` | ✓ | ✓ automatic |
 | `install.sh` | ✓ fatal on mismatch | ~ needs `gh`, installed and authenticated |
 | Homebrew | ✓ | · |
-| `claudebar-installer.sh` (hosted) | ✓ | · |
+| `mise` | ✓ | ✓ automatic |
+| npm / pnpm | ✓ (ships verified binary) | · |
 
 <sub>✓ verified, ~ conditional, · not checked</sub>
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -122,7 +122,7 @@ you mean to release.
 **[SPEC]**
 Run these before tagging to catch problems without burning a tag:
 
-- **`dist plan`** — offline dry-run. Prints the planned artifacts: the four `claudebar-<target>.tar.gz` archives, the per-archive `.sha256` files, the unified `sha256.sum`, and `claudebar-installer.sh`. Use `dist plan --output-format=json` to inspect the build matrix and confirm that the announced version matches `Cargo.toml`.
+- **`dist plan`** — offline dry-run. Prints the planned artifacts: the four `claudebar-<target>.tar.gz` archives, the per-archive `.sha256` files, and the unified `sha256.sum`. Use `dist plan --output-format=json` to inspect the build matrix and confirm that the announced version matches `Cargo.toml`.
 
   ```bash
   dist plan
@@ -156,7 +156,6 @@ Push a throwaway smoke tag to verify the full pipeline end-to-end: real archives
 2. **Confirm the GitHub Release** for `2026.6.99` has:
    - four `claudebar-2026.6.99-<target>.tar.gz`... *— note:* dist names archives by target only, **`claudebar-<target>.tar.gz`** (e.g. `claudebar-x86_64-unknown-linux-musl.tar.gz`), which omits the version segment. Expect four archives, one per target.
    - the unified **`sha256.sum`** checksum file (plus per-archive `.sha256` files).
-   - the **`claudebar-installer.sh`** shell installer.
 
 3. **Download the `x86_64-unknown-linux-musl` archive** and confirm the binary reports the tag:
 


### PR DESCRIPTION
Removes the unused cargo-dist  (no workflow tests it, nothing links it) in favor of the repo's existing . Homebrew publishing stays. Triggers the zizmor pipeline for review.