### PR TITLE
fix(npm): strip cargo-dist target prefix when extracting release assets

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -61,7 +61,9 @@ jobs:
           for a in claudebar-*.tar.gz; do
             t="${a#claudebar-}"; t="${t%.tar.gz}"
             mkdir -p "$RUNNER_TEMP/extracted/$t"
-            tar -xzf "$a" -C "$RUNNER_TEMP/extracted/$t"
+            # cargo-dist tarballs nest the binary under claudebar-<target>/;
+            # strip that prefix so the binary lands at extracted/<target>/claudebar.
+            tar -xzf "$a" -C "$RUNNER_TEMP/extracted/$t" --strip-components=1
           done
 
       - name: Assemble publishable packages (templates + version + binary)


### PR DESCRIPTION
The npm publish failed for 2026.8.24-beta.1: cargo-dist tarballs nest the binary under `claudebar-<target>/`, but the extract step dropped them into `extracted/<target>/` without stripping that prefix, so the copy step couldn't find the binary.

Adds `--strip-components=1` so the binary lands at `extracted/<target>/claudebar` as the workflow expects. Verified against the real 2026.8.24-beta.1 release assets.