### PR TITLE
fix(install): strip cargo-dist target prefix on extract

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -187,13 +187,12 @@ extract_archive() {
     red "Archive contains unsafe paths (.. or absolute) — aborting"
     return 1
   fi
-  tar --no-same-owner -xf "$archive" -C "$dest"
+  # gVisor returns ENOSYS when tar creates a directory then opens files in it.
+  tar --no-same-owner --strip-components=1 -xf "$archive" -C "$dest"
 }
 
 install_binary() {
   local workdir="$1" src
-  # cargo-dist archives nest the binary in a target-named subdirectory
-  # (e.g. claudebar-x86_64-unknown-linux-musl/claudebar), not at the root.
   src=$(find "$workdir" -maxdepth 2 -type f -name claudebar | head -n1)
   if [ -z "$src" ]; then
     red "Extracted archive did not contain a claudebar binary"

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -205,24 +205,26 @@ setup() {
 @test "archive_has_unsafe_paths flags path traversal" {
   mkdir -p sub
   echo evil > sub/x
-  tar -czf evil.tar.gz --transform 's|sub/x|../escape|' sub/x
+  tar -czf evil.tar.gz -C sub --transform 's|^x$|../escape|' x
   run archive_has_unsafe_paths evil.tar.gz
   [ "$status" -eq 0 ]
 }
 
-@test "extract_archive extracts a clean archive" {
-  echo bin > claudebar
-  tar -czf clean.tar.gz claudebar
+@test "extract_archive strips the cargo-dist target directory" {
+  mkdir -p claudebar-x86_64-unknown-linux-musl
+  echo bin > claudebar-x86_64-unknown-linux-musl/claudebar
+  tar -czf clean.tar.gz claudebar-x86_64-unknown-linux-musl
   mkdir out
   run extract_archive clean.tar.gz out
   [ "$status" -eq 0 ]
   [ -f out/claudebar ]
+  [ ! -d out/claudebar-x86_64-unknown-linux-musl ]
 }
 
 @test "extract_archive refuses a traversal archive" {
   mkdir -p sub
   echo evil > sub/x
-  tar -czf evil.tar.gz --transform 's|sub/x|../escape|' sub/x
+  tar -czf evil.tar.gz -C sub --transform 's|^x$|../escape|' x
   mkdir out
   run extract_archive evil.tar.gz out
   [ "$status" -eq 1 ]


### PR DESCRIPTION
## Problem

`install.sh` failed to extract the release tarball under a gVisor-sandboxed kernel:

```
tar: claudebar-x86_64-unknown-linux-musl/claudebar: Cannot open: Function not implemented
tar: Exiting with failure status due to previous errors
```

Root cause is not the archive. `tar` creates the `claudebar-<target>/` directory, then `openat()` for files inside it returns `ENOSYS`. Reproduced with a hand-built two-entry tar, so archive contents are irrelevant. Normal Linux and macOS kernels are unaffected, which is why `verify-install.yml` stayed green.

## Fix

Extract with `--strip-components=1`, dropping the cargo-dist target-named top directory so the payload lands directly in the work dir. `install_binary`'s `find -maxdepth 2` still covers both layouts.

## Tests

`tests/install.bats` used a flat fixture (`claudebar` at the archive root), so the real cargo-dist directory layout was never exercised — the test would have passed no matter what the top directory did. Now nested, and it asserts the prefix is gone.

The two traversal fixtures built their archive as `tar -czf evil.tar.gz sub/x`, which hits the same `ENOSYS` on the create side. Switched to `-C sub ... x`; `tar -tzf` still shows `../escape`, so both tests check the same defense as before.

## Verification

- `bats tests/*.bats` — 56/56 pass (previously 2 failures in this environment)
- `bash -n install.sh`, `shellcheck install.sh` — clean
- Full `bash install.sh` run: downloads 2026.7.21, checksum + attestation verified, binary installed, `settings.json` patched