### PR TITLE
chore(deps): update renovatebot/github-action action to v46.2.4

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: renovatebot/github-action@e09d604f8f803bb527bd8321ed5be06c460b8682 # v46.2.2
+      - uses: renovatebot/github-action@5402b206248e5a8c8427a15102702eb9c1793efc # v46.2.4
         with:
           configurationFile: renovate.json
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Last open item from the Renovate Dependency Dashboard (#33) that had no PR of its own.

`renovatebot/github-action` v46.2.2 → v46.2.4 in `.github/workflows/renovate.yml`.

SHA verified against the tag per the repo convention:

```
gh api repos/renovatebot/github-action/git/ref/tags/v46.2.4
→ {"sha":"5402b206248e5a8c8427a15102702eb9c1793efc","type":"commit"}
```

v46.2.4 is also the current `releases/latest`.

`actionlint` clean with the CI's `SHELLCHECK_OPTS="-S warning"`.