### PR TITLE
fix(tui): hide style-list glyphs for styles with icons off

### DIFF
--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -471,8 +471,13 @@ fn render_style_row(
     let empty2 = format!("{0}{0}", style.bar_empty);
     let fill_span = Span::styled(fill2, Style::default().fg(CHROME_OK));
     let empty_span = Span::styled(empty2, Style::default().fg(CHROME_DISABLED));
-    let project_span = Span::raw(style.glyphs.project);
-    let duration_span = Span::raw(style.glyphs.duration);
+    // Only icon-enabled styles emit glyphs at render time (SegmentWriter::icon gates
+    // on style.icons), so a style with icons off must show none here either.
+    let icon_span = if style.icons {
+        Span::raw(style.glyphs.duration)
+    } else {
+        Span::raw("")
+    };
 
     let mut line = Line::from(vec![
         Span::raw("  "),
@@ -484,9 +489,7 @@ fn render_style_row(
         fill_span,
         empty_span,
         gap_b,
-        project_span,
-        Span::raw(" "),
-        duration_span,
+        icon_span,
     ]);
     if is_cursor {
         line = line.style(cursor_bg);
@@ -1087,4 +1090,36 @@ fn draw_help_overlay(f: &mut Frame, overlay_area: Rect) {
         .border_style(Style::default().fg(CHROME_ACCENT));
 
     f.render_widget(Paragraph::new(content).block(block), overlay_area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::config::Config;
+
+    fn row_text(style_name: &'static str) -> String {
+        let cfg = Config {
+            style: style_name.to_string(),
+            ..Config::default()
+        };
+        let app = App::new(cfg, None);
+        render_style_row(&style_name, &app, false, Style::default())
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect()
+    }
+
+    #[test]
+    fn style_row_shows_icon_only_when_style_enables_icons() {
+        for name in crate::styles::NAMES {
+            let style = crate::styles::get(name);
+            let has_glyph = row_text(name).contains(style.glyphs.duration);
+            assert_eq!(
+                has_glyph, style.icons,
+                "{name}: row shows duration glyph = {has_glyph}, but style.icons = {}",
+                style.icons
+            );
+        }
+    }
 }


### PR DESCRIPTION
Style-Liste im Configurator zeigte Glyphen, die Statusline nie rendert.

**Bug.** `render_style_row` druckte `glyphs.project` und `glyphs.duration` bedingungslos. Renderpfad gated aber auf `style.icons` (`SegmentWriter::icon`, `src/render/writer.rs:93`). Folge: `minimal` (`icons: false`, erbt `POWERLINE.glyphs`) sah in der Liste aus wie `powerline`, rendert aber null Icons. Gilt genauso für `plain` und `ascii`, deren `P`/`d` ebenfalls nie erscheinen.

**Fix.** Glyph-Spalte auf `style.icons` gaten.

**`project`-Glyph gestrichen.** `glyphs.project` (U+2394 ⎔) hatte genau einen Konsumenten: diese Liste. Kein Segment liest es, null Vorkommen im gerenderten Output aller sieben Stile. Dazu fehlt U+2394 in Hack Nerd Font Mono, dem von README und `doctor` empfohlenen Font — die Liste zeigte dort ein Tofu-Kästchen. Spalte zeigt jetzt nur noch `duration`.

**Test.** `render_style_row` war ungetestet. Neuer Test prüft über alle `styles::NAMES`, dass das Glyph genau dann erscheint, wenn `style.icons` gesetzt ist. Gegen den alten Code rot: `plain: row shows duration glyph = true, but style.icons = false`.

Kein Renderverhalten geändert, kein Snapshot betroffen. 270 Tests grün, clippy sauber.

**Nicht in diesem PR:** `unicode` fehlen sieben Glyphen im empfohlenen Font (`branch` U+2387, `token` U+2B21, `worktree` U+2442, `agent` U+2699, `project` U+2394, `stash` U+2691, `duration` U+23F1). U+2B21 landet im echten Output, ist also kein reines TUI-Problem. Eigenes Thema. Ebenso tote Felder `GlyphSet::project` und `GlyphSet::lines`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)