### PR TITLE
fix(release-prep): changelog since last stable tag

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -95,7 +95,19 @@ jobs:
         run: |
           set -euo pipefail
           section="$RUNNER_TEMP/section.md"
-          git-cliff --unreleased --tag "$VERSION" --strip all > "$section"
+          # For a stable release, roll up every commit since the last stable tag
+          # (not just since the last beta) so intermediate betas aren't dropped.
+          if [[ "$VERSION" != *-beta.* ]]; then
+            last_stable="$(git tag -l | grep -vE -- '-beta\.' | sort -V | tail -1)"
+            range="${last_stable:+$last_stable..}"
+          else
+            range=""
+          fi
+          if [[ -n "$range" ]]; then
+            git-cliff "$range" --tag "$VERSION" --strip all > "$section"
+          else
+            git-cliff --unreleased --tag "$VERSION" --strip all > "$section"
+          fi
           grep -q '^### ' "$section" \
             || { echo "::error::git-cliff produced no entries — nothing to release"; exit 1; }
           grep -q '<!-- next-release -->' CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ brew install micschr0/tap/claudebar-beta
 Or via the script:
 
 ```bash
-CLAUDEBAR_CHANNEL=beta curl -fsSL https://raw.githubusercontent.com/micschr0/claudebar/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/micschr0/claudebar/main/install.sh | CLAUDEBAR_CHANNEL=beta bash
 ```
 
 `micschr0/tap/claudebar` always tracks stable; `claudebar-beta` follows the latest prerelease. Back to stable:


### PR DESCRIPTION
git-cliff --unreleased only looks back to the last tag, so a stable release after intermediate betas dropped their changelog entries. Now rolls up everything since the last stable tag when cutting a stable release; betas keep --unreleased.