### PR TITLE
ci: lint scripts with ruff

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,6 +26,19 @@ jobs:
       - name: Run shellcheck
         run: shellcheck -S warning install.sh statusline-command.sh scripts/*.sh
 
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install ruff
+        # Pinned so a new ruff release cannot turn this job red on its own.
+        run: pipx install ruff==0.16.5
+      - name: Run ruff
+        run: ruff check scripts/
+
   actionlint:
     name: actionlint
     runs-on: ubuntu-latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,10 +36,11 @@ tasks:
     cmd: cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
 
   lint:
-    desc: Clippy + shellcheck + actionlint + gitleaks + zizmor
+    desc: Clippy + shellcheck + ruff + actionlint + gitleaks + zizmor
     cmds:
       - cargo clippy -- -D warnings
       - shellcheck -S warning install.sh statusline-command.sh scripts/*.sh
+      - ruff check scripts/
       - actionlint .github/workflows/*.yml
       - zizmor .github/workflows/*.yml
       - gitleaks detect -v

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+# scripts/ are dev-only asset generators, not shipped code. Gate the rules that
+# catch bugs (syntax errors, undefined names, unused imports) and leave style
+# alone — the existing code deliberately uses semicolons and one-line ifs.
+[lint]
+select = ["E9", "F"]

--- a/scripts/gen_screenshots.py
+++ b/scripts/gen_screenshots.py
@@ -18,7 +18,7 @@ Prerequisites for PNG:
     /tmp/demo-{clean,app,busy,release,behind} in distinct git states so the
     screenshots show varied git segments instead of an identical one.
 """
-import subprocess, re, time, os, sys, base64, math, shutil
+import subprocess, re, time, os, sys, base64
 
 REPO     = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Screenshots render the real Rust binary's output (what users actually install),
@@ -822,7 +822,7 @@ def generate_svg():
     o.append(f'<defs><style>{embed_nerd_font(glyph_chars)}</style>')
     o.append(f'<clipPath id="win"><rect width="{SVG_W}" height="{TH}" rx="10"/></clipPath></defs>')
     o.append(f'<rect width="{SVG_W}" height="{TH}" rx="10" fill="{SVG_BORDER}"/>')
-    o.append(f'<g clip-path="url(#win)">')
+    o.append('<g clip-path="url(#win)">')
     o.append(f'<rect width="{SVG_W}" height="{TH}" fill="{SVG_BG}"/>')
     o.append(f'<rect width="{SVG_W}" height="{SVG_TITLEBAR_H}" fill="{SVG_BAR_BG}"/>')
     o.append(f'<rect y="{SVG_TITLEBAR_H-1}" width="{SVG_W}" height="1" fill="#16172a"/>')

--- a/scripts/window_frame.py
+++ b/scripts/window_frame.py
@@ -12,6 +12,7 @@ Output format follows the extension:
 --no-hold keeps every frame's own duration (use for a seamless spinner loop);
 without it the final content frame is held briefly (nicer for step-through demos).
 """
+import os
 import sys
 from PIL import Image, ImageDraw, ImageFont, ImageSequence, ImageFilter
 


### PR DESCRIPTION
Python scripts had no linter. Ruff now gates them.

Found real bug: `scripts/window_frame.py` never imported `os`, so `load_font()` raised `NameError` on every call. Fixed.

Also dropped unused `math`/`shutil` imports and one placeholder-less f-string in `gen_screenshots.py`.

`ruff.toml` selects `E9,F` only — syntax errors, undefined names, unused imports. No style gate: these scripts deliberately use semicolons and one-line ifs, and reformatting all 7 files would be churn.

Wired into `task lint` and a new `Ruff` job in `security.yml` (ruff pinned to 0.16.5 so a release cannot turn CI red on its own).

Verified: `ruff check scripts/` clean, all 7 scripts compile, actionlint + zizmor clean.

Not done: 9 `subprocess.run` calls without `check=`. Real hazard for silently broken screenshot output, but fixing changes runtime behavior — separate PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbWrScXgqWeCR8vZopYLSH