### PR TITLE
chore: drop dead pub API and fix broken doc links

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -589,11 +589,10 @@ fn run_edit(cli: &Cli) -> ExitCode {
         }
     }
 
-    let editor = claudebar::setup::resolve_editor_from(
-        std::env::var("EDITOR").ok(),
-        std::env::var("VISUAL").ok(),
-    )
-    .unwrap_or_else(|| String::from("vi"));
+    let editor = std::env::var("EDITOR")
+        .ok()
+        .or_else(|| std::env::var("VISUAL").ok())
+        .unwrap_or_else(|| String::from("vi"));
 
     let status = std::process::Command::new(&editor).arg(&path).status();
 

--- a/src/model/palette.rs
+++ b/src/model/palette.rs
@@ -10,14 +10,21 @@ use std::fmt::Write;
 pub struct Color(pub u8);
 
 impl Color {
-    /// SGR foreground sequence, e.g. `\x1b[38;5;33m`.
+    /// SGR foreground sequence as an owned `String`, e.g. `\x1b[38;5;33m`.
+    ///
+    /// Test-only: the render path uses [`Color::write_fg`], which appends into
+    /// an existing buffer instead of allocating. This one exists so assertions
+    /// can build an expected escape sequence inline, and is gated so it does
+    /// not sit in the public API or the shipped binary as a slower twin.
+    #[cfg(test)]
     #[must_use = "returns ANSI escape string; ignoring it is a bug"]
     pub fn fg(self) -> String {
         format!("\x1b[38;5;{}m", self.0)
     }
 
     /// Append the SGR foreground sequence directly into `buf`, avoiding the
-    /// throwaway `String` that [`Color::fg`] allocates on the render hot path.
+    /// throwaway `String` an owned-return variant would allocate on the render
+    /// hot path.
     ///
     /// # Panics
     ///

--- a/src/render/bar.rs
+++ b/src/render/bar.rs
@@ -4,8 +4,7 @@
 
 use crate::model::{Color, RESET};
 
-/// Append a self-colored bar of `width` cells for `pct` percent into `buf`,
-/// avoiding the throwaway `String` that [`make_bar`] allocates.
+/// Append a self-colored bar of `width` cells for `pct` percent into `buf`.
 ///
 /// `pct` may exceed 100 (over-limit); the filled run is clamped to `width`.
 #[allow(clippy::too_many_arguments)]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -14,27 +14,6 @@ use std::path::{Path, PathBuf};
 /// formatting external/user input into the JSON `command` field.
 pub const STATUSLINE_COMMAND: &str = "claudebar render";
 
-/// Resolve the claudebar config file path. Pure — no environment reads, so
-/// directly unit-testable. Mirrors the logic in [`crate::model::Config::default_path`]
-/// but takes explicit parameters.
-#[must_use]
-pub fn resolve_config(xdg_config_home: Option<&Path>, home: Option<&Path>) -> PathBuf {
-    if let Some(xdg) = xdg_config_home {
-        xdg.join("claudebar").join("config.toml")
-    } else if let Some(home) = home {
-        home.join(".config").join("claudebar").join("config.toml")
-    } else {
-        PathBuf::from("config.toml")
-    }
-}
-
-/// Resolve the editor command from `EDITOR` / `VISUAL` env var values passed
-/// explicitly. Returns `None` when neither is set.
-#[must_use]
-pub fn resolve_editor_from(editor: Option<String>, visual: Option<String>) -> Option<String> {
-    editor.or(visual)
-}
-
 /// Nerd Font check: look for .ttf/.otf files with "Nerd" or "nerd" in their name.
 /// Uses `fc-list` if available; falls back to scanning common font dirs.
 #[must_use]
@@ -384,45 +363,8 @@ mod tests {
     }
 
     #[test]
-    fn resolve_config_uses_xdg_var_when_set() {
-        let xdg = Path::new("/tmp/xdg");
-        let home = Path::new("/home/user");
-        let result = resolve_config(Some(xdg), Some(home));
-        assert_eq!(result, PathBuf::from("/tmp/xdg/claudebar/config.toml"));
-    }
-
-    #[test]
-    fn resolve_config_falls_back_to_home_when_xdg_unset() {
-        let home = Path::new("/home/user");
-        let result = resolve_config(None, Some(home));
-        assert_eq!(
-            result,
-            PathBuf::from("/home/user/.config/claudebar/config.toml")
-        );
-    }
-
-    #[test]
-    fn resolve_config_defaults_to_relative_when_neither_set() {
-        let result = resolve_config(None, None);
-        assert_eq!(result, PathBuf::from("config.toml"));
-    }
-
-    #[test]
     fn doctor_reports_missing_nerd_font_is_bool() {
         // Structural test: the function must return bool and not panic.
         let _: bool = check_nerd_font();
-    }
-
-    #[test]
-    fn resolve_editor_from_uses_editor_before_visual() {
-        assert_eq!(
-            resolve_editor_from(Some("vim".into()), Some("code".into())),
-            Some("vim".into())
-        );
-        assert_eq!(
-            resolve_editor_from(None, Some("code".into())),
-            Some("code".into())
-        );
-        assert_eq!(resolve_editor_from(None, None), None);
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -69,8 +69,6 @@ pub(crate) struct App {
     pub selectable_indices: Vec<usize>,
     /// Full ordered display rows (headers + selectables + dividers).
     pub list_rows: Vec<RowItem>,
-    /// Top display-row index currently scrolled to.
-    pub scroll_offset: usize,
     /// i-th element of `section_starts` holds the flat_cursor index of the first row in section i.
     pub section_starts: [usize; 4],
     /// Which panel (Left/Right) currently has keyboard focus.
@@ -133,7 +131,6 @@ impl App {
             flat_cursor: 0,
             selectable_indices,
             list_rows,
-            scroll_offset: 0,
             section_starts,
             focused_panel: Panel::Left,
             menu_cursor: 0,
@@ -198,7 +195,6 @@ impl App {
         self.selectable_indices = selectable_indices;
         self.section_starts = section_starts;
         self.flat_cursor = 0;
-        self.scroll_offset = 0;
         self.menu_cursor = 0;
         self.detail_cursor = 0;
         self.focused_panel = Panel::Left;

--- a/src/update.rs
+++ b/src/update.rs
@@ -280,7 +280,7 @@ fn parse_cache(raw: &str) -> Option<CachedCheck> {
 }
 
 /// Whether a background check is due: no cache at all, or one older than
-/// [`REFRESH_INTERVAL`].
+/// `REFRESH_INTERVAL`.
 ///
 /// `saturating_sub` is here for overflow, not for sign: an extreme `checked_at`
 /// would otherwise panic on subtraction in debug builds. A stamp in the future
@@ -294,7 +294,7 @@ fn is_refresh_due(cache: Option<&CachedCheck>, now: i64) -> bool {
 }
 
 /// Spawn a detached `claudebar update --check` when `cached` is missing or
-/// older than [`REFRESH_INTERVAL`].
+/// older than `REFRESH_INTERVAL`.
 ///
 /// Takes the cache the caller has already read — the render path needs the same
 /// value to draw the badge, and reading the file twice per render is waste.


### PR DESCRIPTION
Public API nobody call. Plus doc build red the whole time.

Stacked on #137. Merge in order.

**Dropped:** `setup::resolve_config` (only its own 3 test call it; `Config::default_path` is the real resolver), `setup::resolve_editor_from` (body is `editor.or(visual)`, one caller, inlined), `App::scroll_offset` (written 3 place, read 0).

**Gated, not dropped:** `Color::fg` return owned `String`; render path use `Color::write_fg`. `fg()` only called from test assertion, so `#[cfg(test)]` — deleting would make 4 test site uglier for no gain.

**Doc build was already broken.** `RUSTDOCFLAGS="-D warnings" cargo doc` red on main: `make_bar` intra-doc link point at a function that not exist, and public `refresh_in_background` link to private `REFRESH_INTERVAL`. Both pre-existing, verified by re-running on base. Both fixed. No CI step run `cargo doc`, so it rot — follow-up in #136.

- [x] render matrix **byte-identical**
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` clean — was red on main
- [x] `cargo test` (262, −4 with the deleted fn), `clippy -D warnings`, `fmt --check`, `--no-default-features` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
