### PR TITLE
refactor(tui): remove dead flat-list model, test key dispatch

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -39,38 +39,12 @@ pub(crate) enum Panel {
     Right,
 }
 
-/// A single display row in the flat list. SectionHeader and Divider are
-/// non-selectable; all others can receive flat_cursor.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum RowItem {
-    /// Non-selectable section separator line.
-    SectionHeader(usize), // 0=Segments, 1=Theme, 2=Style, 3=Thresholds
-    /// Selectable segment toggle row.
-    SegmentRow(SegmentKind),
-    /// Non-selectable visual divider between enabled/disabled segments.
-    Divider,
-    /// Selectable theme row.
-    ThemeRow(&'static str),
-    /// Selectable style row.
-    StyleRow(&'static str),
-    /// Selectable threshold nudge row.
-    ThresholdRow(ThresholdField),
-}
-
-/// Full configurator state — single flat-list design.
+/// Full configurator state.
 pub(crate) struct App {
     pub config: Config,
     pub save_path: Option<PathBuf>,
     /// Snapshot at new()/save()/reset() used by is_dirty().
     pub saved_config: Config,
-    /// Index into selectable_indices (the flat cursor).
-    pub flat_cursor: usize,
-    /// Maps flat_cursor → display row index in list_rows.
-    pub selectable_indices: Vec<usize>,
-    /// Full ordered display rows (headers + selectables + dividers).
-    pub list_rows: Vec<RowItem>,
-    /// i-th element of `section_starts` holds the flat_cursor index of the first row in section i.
-    pub section_starts: [usize; 4],
     /// Which panel (Left/Right) currently has keyboard focus.
     pub focused_panel: Panel,
     /// 0–3: which section is highlighted in the left panel.
@@ -122,16 +96,10 @@ impl App {
             })
             .collect();
 
-        let (list_rows, selectable_indices, section_starts) = build_list(&config);
-
         App {
             config,
             save_path,
             saved_config,
-            flat_cursor: 0,
-            selectable_indices,
-            list_rows,
-            section_starts,
             focused_panel: Panel::Left,
             menu_cursor: 0,
             detail_cursor: 0,
@@ -159,13 +127,6 @@ impl App {
         &self.samples[self.sample_idx]
     }
 
-    /// The RowItem currently under flat_cursor.
-    pub(crate) fn cursor_row(&self) -> Option<&RowItem> {
-        self.selectable_indices
-            .get(self.flat_cursor)
-            .and_then(|&dr| self.list_rows.get(dr))
-    }
-
     /// Advance the preview sample forward.
     pub(crate) fn cycle_sample(&mut self) {
         self.sample_idx = (self.sample_idx + 1) % self.samples.len();
@@ -186,15 +147,10 @@ impl App {
         self.pending_quit = true;
     }
 
-    /// Reset config to defaults; rebuild list; reset cursor/scroll.
+    /// Reset config to defaults and send both cursors home.
     pub(crate) fn reset(&mut self) {
         self.config = Config::default();
         self.saved_config = Config::default();
-        let (list_rows, selectable_indices, section_starts) = build_list(&self.config);
-        self.list_rows = list_rows;
-        self.selectable_indices = selectable_indices;
-        self.section_starts = section_starts;
-        self.flat_cursor = 0;
         self.menu_cursor = 0;
         self.detail_cursor = 0;
         self.focused_panel = Panel::Left;
@@ -223,9 +179,9 @@ impl App {
         }
     }
 
-    /// Toggle the segment under detail_cursor; rebuild list; both cursors follow segment.
-    /// detail_cursor indexes into the display order (enabled first, then disabled in ALL order).
-    /// flat_cursor is also updated for backward compat with unit tests that use cursor_row().
+    /// Toggle the segment under `detail_cursor`; the cursor follows it.
+    /// `detail_cursor` indexes into the display order (enabled first, then
+    /// disabled in `SegmentKind::ALL` order).
     pub(crate) fn toggle_cursor(&mut self) {
         // Build display order for segments: enabled in config.segments order, then disabled in ALL order.
         let display_order: Vec<SegmentKind> = {
@@ -244,10 +200,6 @@ impl App {
         };
 
         toggle_segment(&mut self.config.segments, kind);
-        let (list_rows, selectable_indices, section_starts) = build_list(&self.config);
-        self.list_rows = list_rows;
-        self.selectable_indices = selectable_indices;
-        self.section_starts = section_starts;
 
         // Update detail_cursor to follow the toggled segment in new display order.
         let new_display_order: Vec<SegmentKind> = {
@@ -261,23 +213,6 @@ impl App {
         };
         if let Some(idx) = new_display_order.iter().position(|&k| k == kind) {
             self.detail_cursor = idx;
-        }
-
-        // Also update flat_cursor for backward compat with unit tests.
-        if let Some(si) = self
-            .selectable_indices
-            .iter()
-            .enumerate()
-            .find_map(|(si, &dr)| {
-                if let RowItem::SegmentRow(k) = &self.list_rows[dr]
-                    && *k == kind
-                {
-                    return Some(si);
-                }
-                None
-            })
-        {
-            self.flat_cursor = si;
         }
     }
 
@@ -331,8 +266,6 @@ impl App {
 
     /// Apply move-is-select for theme/style sections after navigation.
     /// In the two-panel model, keyed to menu_cursor + detail_cursor.
-    /// Falls back to cursor_row() when menu_cursor == 0 for backward
-    /// compatibility with unit tests that manipulate flat_cursor directly.
     pub(crate) fn apply_move_is_select(&mut self) {
         match self.menu_cursor {
             1 => {
@@ -345,18 +278,8 @@ impl App {
                     self.config.style = name.to_string();
                 }
             }
-            _ => {
-                // Backward compat: flat-cursor callers (unit tests) use cursor_row().
-                match self.cursor_row().cloned() {
-                    Some(RowItem::ThemeRow(name)) => {
-                        self.config.theme = name.to_string();
-                    }
-                    Some(RowItem::StyleRow(name)) => {
-                        self.config.style = name.to_string();
-                    }
-                    _ => {}
-                }
-            }
+            // Segments and Thresholds have nothing to select on move.
+            _ => {}
         }
     }
 
@@ -392,81 +315,6 @@ impl App {
             _ => None,
         }
     }
-}
-
-/// Build list_rows, selectable_indices, and section_starts from config.
-/// Called in App::new(), toggle_cursor(), reset(), and move_segment().
-pub(crate) fn build_list(config: &Config) -> (Vec<RowItem>, Vec<usize>, [usize; 4]) {
-    let mut list_rows: Vec<RowItem> = Vec::with_capacity(
-        4 + SegmentKind::ALL.len()
-            + 1
-            + crate::themes::NAMES.len()
-            + crate::styles::NAMES.len()
-            + 4,
-    );
-    let mut selectable_indices: Vec<usize> = Vec::with_capacity(
-        SegmentKind::ALL.len() + crate::themes::NAMES.len() + crate::styles::NAMES.len() + 4,
-    );
-
-    // --- Section 0: Segments ---
-    list_rows.push(RowItem::SectionHeader(0));
-    // Enabled segments in config.segments order, then disabled in ALL order.
-    let enabled_count = config.segments.len();
-    let total = SegmentKind::ALL.len();
-    // Enabled first.
-    for &kind in &config.segments {
-        selectable_indices.push(list_rows.len());
-        list_rows.push(RowItem::SegmentRow(kind));
-    }
-    // Divider only when some are enabled and some are disabled.
-    if enabled_count > 0 && enabled_count < total {
-        list_rows.push(RowItem::Divider);
-    }
-    // Disabled in canonical order.
-    for &kind in &SegmentKind::ALL {
-        if !config.segments.contains(&kind) {
-            selectable_indices.push(list_rows.len());
-            list_rows.push(RowItem::SegmentRow(kind));
-        }
-    }
-
-    // --- Section 1: Theme ---
-    list_rows.push(RowItem::SectionHeader(1));
-    for &name in crate::themes::NAMES {
-        selectable_indices.push(list_rows.len());
-        list_rows.push(RowItem::ThemeRow(name));
-    }
-
-    // --- Section 2: Style ---
-    list_rows.push(RowItem::SectionHeader(2));
-    for &name in crate::styles::NAMES {
-        selectable_indices.push(list_rows.len());
-        list_rows.push(RowItem::StyleRow(name));
-    }
-
-    // --- Section 3: Thresholds ---
-    list_rows.push(RowItem::SectionHeader(3));
-    selectable_indices.push(list_rows.len());
-    list_rows.push(RowItem::ThresholdRow(ThresholdField::Warn));
-    selectable_indices.push(list_rows.len());
-    list_rows.push(RowItem::ThresholdRow(ThresholdField::Crit));
-    selectable_indices.push(list_rows.len());
-    list_rows.push(RowItem::ThresholdRow(ThresholdField::WeeklyShowAt));
-    selectable_indices.push(list_rows.len());
-    list_rows.push(RowItem::ThresholdRow(ThresholdField::BarWidth));
-
-    // section_starts[i] = flat_cursor of first selectable in section i.
-    let seg_count = SegmentKind::ALL.len();
-    let theme_count = crate::themes::NAMES.len();
-    let style_count = crate::styles::NAMES.len();
-    let section_starts: [usize; 4] = [
-        0,
-        seg_count,
-        seg_count + theme_count,
-        seg_count + theme_count + style_count,
-    ];
-
-    (list_rows, selectable_indices, section_starts)
 }
 
 /// Enable seg (append) if absent, else disable it (remove).
@@ -612,13 +460,6 @@ mod tests {
     }
 
     #[test]
-    fn step_clamps_at_ends() {
-        // flat_cursor clamp logic: saturating_sub and .min(max_idx)
-        assert_eq!(0usize.saturating_sub(1), 0);
-        assert_eq!(4, 4);
-    }
-
-    #[test]
     fn new_syncs_theme_style_cursors() {
         let cfg = Config {
             theme: "nord".into(),
@@ -626,49 +467,8 @@ mod tests {
             ..Config::default()
         };
         let app = App::new(cfg, None);
-        // In the flat list, theme section starts at section_starts[1]=5.
-        // Nord is at index 3 in NAMES, so flat_cursor for nord would be 5+3=8.
-        // But App::new() starts flat_cursor at 0 — just verify config is right.
         assert_eq!(app.config.theme, "nord");
         assert_eq!(app.config.style, "ascii");
-    }
-
-    #[test]
-    fn moving_theme_cursor_updates_config_and_dirty() {
-        let mut app = App::new(Config::default(), None);
-        // Jump to theme section via flat_cursor (backward compat with old flat-list model).
-        app.flat_cursor = app.section_starts[1];
-        let before = app.config.theme.clone();
-        // Simulate j press: move down, apply move-is-select.
-        let max_idx = app.selectable_indices.len().saturating_sub(1);
-        if app.flat_cursor < max_idx {
-            app.flat_cursor += 1;
-        }
-        app.apply_move_is_select();
-        assert_ne!(app.config.theme, before);
-        assert!(app.is_dirty());
-    }
-
-    #[test]
-    fn moving_cursor_at_boundary_does_not_set_dirty() {
-        let mut app = App::new(Config::default(), None);
-        // Jump to first theme row (flat_cursor = section_starts[1]).
-        app.flat_cursor = app.section_starts[1];
-        // Move up — stays on same theme row, no change.
-        let _before = app.config.theme.clone();
-        if app.flat_cursor > 0 {
-            app.flat_cursor -= 1;
-        }
-        // This moves into the last segment row, not a theme row — no theme change.
-        // For this test: manually put cursor on first theme and try to go up within themes.
-        app.flat_cursor = app.section_starts[1]; // first theme
-        let saved = app.config.theme.clone();
-        // Going up from first theme would go to a segment row, not apply theme change.
-        // Theme move-is-select only applies when landing on a ThemeRow.
-        // So staying on the same theme row (boundary) leaves config unchanged.
-        app.apply_move_is_select(); // still on first theme
-        assert_eq!(app.config.theme, saved);
-        assert!(!app.is_dirty());
     }
 
     #[test]
@@ -676,10 +476,6 @@ mod tests {
         let mut app = App::new(Config::default(), None);
         app.config.theme = "dracula".into();
         app.config.segments.clear();
-        let (rows, si, ss) = build_list(&app.config);
-        app.list_rows = rows;
-        app.selectable_indices = si;
-        app.section_starts = ss;
         app.reset();
         assert_eq!(app.config, Config::default());
         assert!(!app.is_dirty());
@@ -696,40 +492,6 @@ mod tests {
         app.save();
         assert!(!app.is_dirty());
         let _ = std::fs::remove_file(path);
-    }
-
-    #[test]
-    fn toggle_cursor_sets_dirty_and_follows_segment() {
-        let mut app = App::new(Config::default(), None);
-        app.flat_cursor = 0; // Directory (enabled)
-        let seg = if let Some(RowItem::SegmentRow(k)) = app.cursor_row() {
-            *k
-        } else {
-            panic!("expected SegmentRow at cursor 0");
-        };
-        app.toggle_cursor(); // disable it → moves to end of disabled list
-        assert!(!app.config.segments.contains(&seg));
-        assert!(app.is_dirty());
-        // Cursor should follow the segment to its new position.
-        assert!(matches!(app.cursor_row(), Some(RowItem::SegmentRow(k)) if *k == seg));
-    }
-
-    #[test]
-    fn seg_order_lists_disabled_after_enabled() {
-        let cfg = Config {
-            segments: vec![SegmentKind::Model, SegmentKind::Git],
-            ..Config::default()
-        };
-        let app = App::new(cfg, None);
-        // First two selectable rows should be Model and Git.
-        assert!(matches!(
-            app.list_rows[app.selectable_indices[0]],
-            RowItem::SegmentRow(SegmentKind::Model)
-        ));
-        assert!(matches!(
-            app.list_rows[app.selectable_indices[1]],
-            RowItem::SegmentRow(SegmentKind::Git)
-        ));
     }
 
     #[test]
@@ -756,50 +518,5 @@ mod tests {
         app.request_quit();
         assert!(app.pending_quit);
         // New design: status is NOT written by request_quit().
-    }
-
-    #[test]
-    fn reorder_follows_cursor_in_display_order() {
-        let mut app = App::new(Config::default(), None);
-        // Cursor on second segment (Git at flat_cursor=1).
-        app.flat_cursor = 1;
-        let moved_kind = if let Some(RowItem::SegmentRow(k)) = app.cursor_row() {
-            *k
-        } else {
-            panic!("expected SegmentRow");
-        };
-        // Move up.
-        if let Some(&seg_idx) = app
-            .config
-            .segments
-            .iter()
-            .position(|s| *s == moved_kind)
-            .as_ref()
-            && seg_idx > 0
-        {
-            move_segment(&mut app.config.segments, seg_idx, Dir::Up);
-            let (rows, si, ss) = build_list(&app.config);
-            app.list_rows = rows;
-            app.selectable_indices = si;
-            app.section_starts = ss;
-            // Cursor follows moved segment.
-            if let Some(new_si) = app
-                .selectable_indices
-                .iter()
-                .enumerate()
-                .find_map(|(si, &dr)| {
-                    if let RowItem::SegmentRow(k) = &app.list_rows[dr]
-                        && *k == moved_kind
-                    {
-                        return Some(si);
-                    }
-                    None
-                })
-            {
-                app.flat_cursor = new_si;
-            }
-        }
-        assert!(matches!(app.cursor_row(), Some(RowItem::SegmentRow(k)) if *k == moved_kind));
-        assert_eq!(app.config.segments[0], moved_kind);
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -6,9 +6,7 @@ mod preview;
 mod sample;
 mod ui;
 
-use app::{
-    App, Dir, Panel, RowItem, StatusKind, ThresholdField, build_list, detail_len, move_segment,
-};
+use app::{App, Dir, Panel, StatusKind, ThresholdField, detail_len, move_segment};
 use crossterm::ExecutableCommand;
 use crossterm::event::{
     self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
@@ -259,32 +257,10 @@ fn handle_reorder(app: &mut App, key: KeyEvent) {
 }
 
 fn rebuild_and_follow(app: &mut App, moved_kind: crate::model::SegmentKind) {
-    let (list_rows, selectable_indices, section_starts) = build_list(&app.config);
-    app.list_rows = list_rows;
-    app.selectable_indices = selectable_indices;
-    app.section_starts = section_starts;
-
     // In reorder mode, the moved segment is always enabled, so its index in
     // config.segments equals its position in the right panel's item list.
     if let Some(idx) = app.config.segments.iter().position(|&k| k == moved_kind) {
         app.detail_cursor = idx;
-    }
-
-    // Also update flat_cursor for backward compat with unit tests.
-    if let Some(new_si) = app
-        .selectable_indices
-        .iter()
-        .enumerate()
-        .find_map(|(si, &dr)| {
-            if let RowItem::SegmentRow(k) = &app.list_rows[dr]
-                && *k == moved_kind
-            {
-                return Some(si);
-            }
-            None
-        })
-    {
-        app.flat_cursor = new_si;
     }
 }
 
@@ -505,5 +481,354 @@ fn handle_mouse(app: &mut App, event: MouseEvent) {
             }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Config, SegmentKind};
+
+    /// The configurator's navigation runs entirely on `focused_panel`,
+    /// `menu_cursor` and `detail_cursor`. These tests drive `handle_key` — the
+    /// real dispatch the event loop calls — and assert on those fields only, so
+    /// they pin behaviour rather than any particular internal representation.
+    fn app() -> App {
+        App::new(Config::default(), None)
+    }
+
+    fn press(app: &mut App, c: char) {
+        handle_key(app, KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+    }
+
+    fn press_code(app: &mut App, code: KeyCode) {
+        handle_key(app, KeyEvent::new(code, KeyModifiers::NONE));
+    }
+
+    fn press_all(app: &mut App, keys: &str) {
+        for c in keys.chars() {
+            press(app, c);
+        }
+    }
+
+    // ── Panel focus ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn h_and_l_move_panel_focus() {
+        let mut a = app();
+        press(&mut a, 'l');
+        assert_eq!(a.focused_panel, Panel::Right);
+        press(&mut a, 'h');
+        assert_eq!(a.focused_panel, Panel::Left);
+    }
+
+    #[test]
+    fn arrow_keys_move_panel_focus() {
+        let mut a = app();
+        press_code(&mut a, KeyCode::Right);
+        assert_eq!(a.focused_panel, Panel::Right);
+        press_code(&mut a, KeyCode::Left);
+        assert_eq!(a.focused_panel, Panel::Left);
+    }
+
+    #[test]
+    fn tab_and_backtab_both_toggle_focus() {
+        // Documented quirk: Shift-Tab toggles rather than reversing.
+        let mut a = app();
+        press_code(&mut a, KeyCode::Tab);
+        assert_eq!(a.focused_panel, Panel::Right);
+        press_code(&mut a, KeyCode::Tab);
+        assert_eq!(a.focused_panel, Panel::Left);
+        press_code(&mut a, KeyCode::BackTab);
+        assert_eq!(a.focused_panel, Panel::Right);
+        press_code(&mut a, KeyCode::BackTab);
+        assert_eq!(a.focused_panel, Panel::Left);
+    }
+
+    // ── Section jumps ────────────────────────────────────────────────────────
+
+    #[test]
+    fn digits_jump_to_section_and_focus_right() {
+        for (key, want) in [('1', 0), ('2', 1), ('3', 2), ('4', 3)] {
+            let mut a = app();
+            press(&mut a, key);
+            assert_eq!(a.menu_cursor, want, "key {key} selects section {want}");
+            assert_eq!(a.detail_cursor, 0, "key {key} resets the detail cursor");
+            assert_eq!(
+                a.focused_panel,
+                Panel::Right,
+                "key {key} focuses the right panel"
+            );
+        }
+    }
+
+    // ── Cursor movement ──────────────────────────────────────────────────────
+
+    #[test]
+    fn jk_move_menu_cursor_in_left_panel() {
+        let mut a = app();
+        assert_eq!(a.focused_panel, Panel::Left);
+        press_all(&mut a, "jj");
+        assert_eq!(a.menu_cursor, 2);
+        press(&mut a, 'k');
+        assert_eq!(a.menu_cursor, 1);
+    }
+
+    #[test]
+    fn menu_cursor_clamps_at_both_ends() {
+        let mut a = app();
+        press_all(&mut a, "kkk");
+        assert_eq!(a.menu_cursor, 0, "cannot go above the first section");
+        press_all(&mut a, "jjjjjj");
+        assert_eq!(a.menu_cursor, 3, "cannot go past the last section");
+    }
+
+    #[test]
+    fn jk_move_detail_cursor_in_right_panel() {
+        let mut a = app();
+        press(&mut a, '1');
+        press_all(&mut a, "jj");
+        assert_eq!(a.detail_cursor, 2);
+        press(&mut a, 'k');
+        assert_eq!(a.detail_cursor, 1);
+    }
+
+    #[test]
+    fn detail_cursor_clamps_at_the_end_of_the_section() {
+        let mut a = app();
+        press(&mut a, '3'); // Style section
+        for _ in 0..50 {
+            press(&mut a, 'j');
+        }
+        assert_eq!(a.detail_cursor, crate::styles::NAMES.len() - 1);
+    }
+
+    #[test]
+    fn g_and_shift_g_jump_to_first_and_last() {
+        let mut a = app();
+        press(&mut a, '2'); // Theme section
+        press(&mut a, 'G');
+        assert_eq!(a.detail_cursor, crate::themes::NAMES.len() - 1);
+        press(&mut a, 'g');
+        assert_eq!(a.detail_cursor, 0);
+    }
+
+    #[test]
+    fn switching_section_clamps_a_now_out_of_range_detail_cursor() {
+        let mut a = app();
+        press(&mut a, '2'); // Themes: 16 entries
+        press(&mut a, 'G');
+        let themes_last = a.detail_cursor;
+        press(&mut a, 'h'); // back to the left panel
+        press(&mut a, 'k'); // up to Segments: 12 entries
+        assert_eq!(a.menu_cursor, 0);
+        assert!(
+            a.detail_cursor < themes_last,
+            "detail cursor must be clamped into the shorter section"
+        );
+        assert_eq!(a.detail_cursor, SegmentKind::ALL.len() - 1);
+    }
+
+    // ── Theme and style selection ────────────────────────────────────────────
+
+    #[test]
+    fn moving_in_theme_section_applies_the_theme() {
+        let mut a = app();
+        press(&mut a, '2');
+        press(&mut a, 'j');
+        assert_eq!(a.config.theme, crate::themes::NAMES[1]);
+        press(&mut a, 'G');
+        press(&mut a, 'k');
+        assert_eq!(
+            a.config.theme,
+            crate::themes::NAMES[crate::themes::NAMES.len() - 2]
+        );
+    }
+
+    #[test]
+    fn moving_in_style_section_applies_the_style() {
+        let mut a = app();
+        press(&mut a, '3');
+        press(&mut a, 'j');
+        assert_eq!(a.config.style, crate::styles::NAMES[1]);
+    }
+
+    // ── Segments ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn space_toggles_the_segment_under_the_cursor() {
+        let mut a = app();
+        press(&mut a, '1');
+        let first = a.config.segments[0];
+        press_code(&mut a, KeyCode::Char(' '));
+        assert!(
+            !a.config.segments.contains(&first),
+            "space must disable the focused segment"
+        );
+        // The cursor follows the segment into the disabled group; toggling again
+        // must bring it back.
+        press_code(&mut a, KeyCode::Char(' '));
+        assert!(a.config.segments.contains(&first));
+    }
+
+    #[test]
+    fn m_enters_reorder_mode_only_for_an_enabled_segment() {
+        let mut a = app();
+        press(&mut a, '1');
+        press(&mut a, 'm');
+        assert!(a.reorder_mode, "an enabled segment can be reordered");
+
+        let mut b = app();
+        press(&mut b, '1');
+        press(&mut b, 'G'); // last row is a disabled segment
+        press(&mut b, 'm');
+        assert!(!b.reorder_mode, "a disabled segment cannot be reordered");
+        assert!(b.status.is_some(), "and the refusal is explained");
+    }
+
+    #[test]
+    fn reorder_moves_the_segment_and_the_cursor_follows_it() {
+        let mut a = app();
+        press(&mut a, '1');
+        let moved = a.config.segments[0];
+        press(&mut a, 'm');
+        press(&mut a, 'j');
+        assert_eq!(a.config.segments[1], moved, "segment moved down one slot");
+        assert_eq!(a.detail_cursor, 1, "cursor follows the moved segment");
+        press(&mut a, 'k');
+        assert_eq!(a.config.segments[0], moved, "and back up again");
+        assert_eq!(a.detail_cursor, 0);
+    }
+
+    #[test]
+    fn reorder_mode_exits_on_m_and_esc() {
+        let mut a = app();
+        press(&mut a, '1');
+        press(&mut a, 'm');
+        press(&mut a, 'm');
+        assert!(!a.reorder_mode);
+
+        press(&mut a, 'm');
+        assert!(a.reorder_mode);
+        press_code(&mut a, KeyCode::Esc);
+        assert!(!a.reorder_mode);
+    }
+
+    // ── Thresholds ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn minus_and_equals_nudge_the_focused_threshold_by_one() {
+        let mut a = app();
+        press(&mut a, '4');
+        let before = a.config.thresholds.warn;
+        press(&mut a, '=');
+        assert_eq!(a.config.thresholds.warn, before + 1);
+        press(&mut a, '-');
+        assert_eq!(a.config.thresholds.warn, before);
+    }
+
+    #[test]
+    fn underscore_and_plus_nudge_by_five() {
+        let mut a = app();
+        press(&mut a, '4');
+        let before = a.config.thresholds.warn;
+        press(&mut a, '+');
+        assert_eq!(a.config.thresholds.warn, before + 5);
+        press(&mut a, '_');
+        assert_eq!(a.config.thresholds.warn, before);
+    }
+
+    #[test]
+    fn space_cycles_an_enum_threshold() {
+        let mut a = app();
+        press(&mut a, '4');
+        press(&mut a, 'G'); // last threshold row is the Layout enum
+        let before = a.config.thresholds.layout.clone();
+        press_code(&mut a, KeyCode::Char(' '));
+        assert_ne!(a.config.thresholds.layout, before, "space cycles the value");
+    }
+
+    #[test]
+    fn nudge_keys_do_nothing_outside_the_thresholds_section() {
+        let mut a = app();
+        press(&mut a, '1'); // Segments
+        let before = a.config.thresholds.clone();
+        press_all(&mut a, "=-+_");
+        assert_eq!(a.config.thresholds, before);
+    }
+
+    // ── Preview samples ──────────────────────────────────────────────────────
+
+    #[test]
+    fn p_cycles_the_preview_sample_both_ways() {
+        let mut a = app();
+        let n = a.samples.len();
+        press(&mut a, 'p');
+        assert_eq!(a.sample_idx, 1);
+        press(&mut a, 'P');
+        assert_eq!(a.sample_idx, 0);
+        press(&mut a, 'P');
+        assert_eq!(a.sample_idx, n - 1, "wraps backwards past the start");
+    }
+
+    // ── Overlays and guards ──────────────────────────────────────────────────
+
+    #[test]
+    fn question_mark_opens_help_and_help_swallows_input() {
+        let mut a = app();
+        press(&mut a, '?');
+        assert!(a.show_help);
+
+        // While the overlay is up, navigation must not move underneath it.
+        let menu_before = a.menu_cursor;
+        press_all(&mut a, "jjj");
+        assert_eq!(
+            a.menu_cursor, menu_before,
+            "help overlay swallows navigation"
+        );
+
+        press(&mut a, '?');
+        assert!(!a.show_help);
+    }
+
+    #[test]
+    fn quitting_clean_exits_but_dirty_asks_first() {
+        let mut a = app();
+        press(&mut a, 'q');
+        assert!(a.should_quit, "a clean config quits straight away");
+
+        let mut b = app();
+        press(&mut b, '2');
+        press(&mut b, 'j'); // changes the theme -> dirty
+        assert!(b.is_dirty());
+        press(&mut b, 'q');
+        assert!(!b.should_quit, "a dirty config must not quit silently");
+        assert!(b.pending_quit, "it arms the confirmation instead");
+        press(&mut b, 'q');
+        assert!(b.should_quit, "confirming quits");
+    }
+
+    #[test]
+    fn reset_is_two_press_guarded() {
+        let mut a = app();
+        press(&mut a, '2');
+        press(&mut a, 'j');
+        assert!(a.is_dirty());
+        press(&mut a, 'r');
+        assert!(a.pending_reset, "first press only arms the guard");
+        assert!(a.is_dirty(), "and changes nothing yet");
+    }
+
+    #[test]
+    fn navigation_keys_do_not_cancel_a_pending_guard() {
+        let mut a = app();
+        press(&mut a, 'r');
+        assert!(a.pending_reset);
+        press_all(&mut a, "jk1234");
+        press_code(&mut a, KeyCode::Tab);
+        assert!(
+            a.pending_reset,
+            "navigation must preserve the confirmation banner"
+        );
     }
 }


### PR DESCRIPTION
Whole parallel data model nobody read. Plus first ever test for key dispatch.

Stacked on #127. Merge in order.

**Dead:** `RowItem`, `build_list()`, `list_rows`, `selectable_indices`, `flat_cursor`, `cursor_row()`, `section_starts` — leftover from an earlier flat-list design. `ui.rs` read none of it; drawing go through `build_*_lines`, navigation through `focused_panel` + `menu_cursor` + `detail_cursor`. Only thing keeping it alive was a sync block "for backward compat with unit tests" — the test tested the dead thing, the dead thing existed for the test.

**The danger:** those were the only TUI test. Deleting model + test together leave no net at the exact moment one needed. So new test first, against `handle_key` — 24 test covering every key in the CLAUDE.md table. Green before deletion, unchanged after.

**tmux verification.** Drove the real TUI, `capture-pane -e -p` raw ANSI, 25 navigation state. Harness proven deterministic first (two run, same binary, 25/25 identical), then before vs after: **25/25 byte-identical**.

production −174 line, test +216, key dispatch 0 → covered.

- [x] tmux 25/25 identical, render matrix byte-identical
- [x] `cargo test` (281), `clippy -D warnings`, `fmt --check`, `--no-default-features` build

> Noticed, not fixed here: display order computed in several place. Fixed in #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
