### PR TITLE
refactor: generate theme and style registries from one list

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,59 @@
     clippy::cast_sign_loss
 )]
 
+/// Declare a name → value registry from one list.
+///
+/// Generates `NAMES` (display order) and `get()` (name lookup with a fallback)
+/// from a single set of entries, so a name can never exist without a matching
+/// arm. That failure mode is not hypothetical: `rounded` sat in `styles::NAMES`
+/// with no arm in `get()` for its entire life, silently resolving to Powerline,
+/// and the tests of the day could not see it.
+macro_rules! registry {
+    ($ty:ty, $fallback:ident, $($name:literal => $konst:ident),+ $(,)?) => {
+        /// Every built-in name, in display order.
+        pub const NAMES: &[&str] = &[$($name),+];
+
+        /// Resolve a name. Unknown names fall back to the default.
+        #[must_use]
+        pub fn get(name: &str) -> $ty {
+            match name {
+                $($name => $konst,)+
+                _ => $fallback,
+            }
+        }
+
+        #[cfg(test)]
+        mod registry_tests {
+            use super::*;
+
+            /// Every name must resolve to its *own* value. A name whose arm is
+            /// missing falls through to the default and collides with it —
+            /// exactly the `rounded` bug, now impossible to reintroduce.
+            #[test]
+            fn every_name_resolves_to_a_distinct_value() {
+                let mut seen: Vec<(&str, $ty)> = Vec::new();
+                for &name in NAMES {
+                    let got = get(name);
+                    if let Some((other, _)) = seen.iter().find(|(_, v)| *v == got) {
+                        panic!(
+                            "{name:?} resolves to the same value as {other:?} — \
+                             missing match arm, or two entries share a constant"
+                        );
+                    }
+                    seen.push((name, got));
+                }
+                assert_eq!(seen.len(), NAMES.len());
+            }
+
+            #[test]
+            fn an_unknown_name_falls_back() {
+                assert_eq!(get("no-such-entry"), $fallback);
+            }
+        }
+    };
+}
+pub(crate) use registry;
+
 pub mod model;
 pub mod paths;
 pub mod render;

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -6,7 +6,11 @@
 
 /// The set of glyphs a style uses. Nerd Font PUA glyphs for rich styles, ASCII
 /// for the fallback. Stored as `&'static str` because some glyphs are multi-byte.
-#[derive(Debug, Clone, Copy)]
+///
+/// `PartialEq` lets the style registry assert that every registered name
+/// resolves to a distinct style — the check that a per-field comparison was
+/// too coarse to make.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GlyphSet {
     /// Branch icon preceding the branch name.
     pub branch: &'static str,
@@ -57,7 +61,7 @@ pub struct GlyphSet {
 }
 
 /// A complete visual style: how segments are separated and decorated.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Style {
     /// Separator glyph placed between adjacent non-empty segments (painted in
     /// the theme's `separator` color, with a space on each side).

--- a/src/styles/mod.rs
+++ b/src/styles/mod.rs
@@ -3,18 +3,6 @@
 
 use crate::model::{GlyphSet, Style};
 
-/// All built-in style names, in display order. Powerline is the default.
-pub const NAMES: &[&str] = &[
-    "powerline",
-    "lean",
-    "plain",
-    "rounded",
-    "minimal",
-    "unicode",
-    "ascii",
-    "dots",
-];
-
 /// powerline style.
 pub const POWERLINE: Style = Style {
     separator: "\u{e0b1}",
@@ -61,39 +49,16 @@ pub const LEAN: Style = Style {
     glyphs: POWERLINE.glyphs,
 };
 
-/// plain style.
+/// plain style — ASCII with a different worktree marker.
+///
+/// Byte-identical to [`ASCII`] apart from `worktree`; spelling out all 23
+/// glyphs again would just be a second copy to keep in sync.
 pub const PLAIN: Style = Style {
-    separator: "|",
-    window_gap: ":",
-    icons: false,
-    bar_fill: '#',
-    bar_empty: '-',
-    bar_dots: None,
     glyphs: GlyphSet {
-        branch: "",
-        ahead: "^",
-        behind: "v",
-        modified: "M",
-        untracked: "?",
-        context: "",
-        token: "#",
-        clock: "",
-        weekly: "W",
-        reset: "~",
-        model: "@",
-        effort: "*",
         worktree: "+",
-        pull_request: "#",
-        review_ok: "+",
-        review_fail: "x",
-        agent: "&",
-        stash: "s",
-        lines: "-",
-        cost: "$",
-        duration: "d",
-        time: "T",
-        burn: "B",
+        ..ASCII.glyphs
     },
+    ..ASCII
 };
 
 /// rounded style.
@@ -205,46 +170,13 @@ pub const DOTS: Style = Style {
     glyphs: POWERLINE.glyphs,
 };
 
-/// Resolve a style by name. Unknown names fall back to Powerline.
-#[must_use]
-pub fn get(name: &str) -> Style {
-    match name {
-        "lean" => LEAN,
-        "rounded" => ROUNDED,
-        "dots" => DOTS,
-        "plain" => PLAIN,
-        "minimal" => MINIMAL,
-        "unicode" => UNICODE,
-        "ascii" => ASCII,
-        _ => POWERLINE,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn every_name_resolves_to_its_own_style() {
-        let expected = [
-            ("powerline", POWERLINE),
-            ("lean", LEAN),
-            ("plain", PLAIN),
-            ("rounded", ROUNDED),
-            ("minimal", MINIMAL),
-            ("unicode", UNICODE),
-            ("ascii", ASCII),
-            ("dots", DOTS),
-        ];
-        assert_eq!(expected.len(), NAMES.len(), "NAMES and the table disagree");
-        for (name, want) in expected {
-            let got = get(name);
-            assert_eq!(got.separator, want.separator, "{name}: separator");
-            assert_eq!(got.bar_fill, want.bar_fill, "{name}: bar_fill");
-            assert_eq!(got.bar_dots, want.bar_dots, "{name}: bar_dots");
-        }
-    }
-    #[test]
-    fn unknown_falls_back_to_powerline() {
-        assert_eq!(get("nope").separator, POWERLINE.separator);
-    }
+crate::registry! { Style, POWERLINE,
+    "powerline" => POWERLINE,
+    "lean"      => LEAN,
+    "plain"     => PLAIN,
+    "rounded"   => ROUNDED,
+    "minimal"   => MINIMAL,
+    "unicode"   => UNICODE,
+    "ascii"     => ASCII,
+    "dots"      => DOTS,
 }

--- a/src/themes/mod.rs
+++ b/src/themes/mod.rs
@@ -3,26 +3,6 @@
 
 use crate::model::{Color, Theme};
 
-/// All built-in theme names, in display order. Tokyo Night remains the default.
-pub const NAMES: &[&str] = &[
-    "tokyo-night",
-    "ayu-mirage",
-    "catppuccin",
-    "cobalt2",
-    "everforest-dark",
-    "github-dark",
-    "gruvbox",
-    "kanagawa-wave",
-    "moonfly",
-    "night-owl",
-    "nord",
-    "one-dark",
-    "dracula",
-    "rose-pine",
-    "sonokai",
-    "solarized-dark",
-];
-
 /// tokyo-night palette.
 pub const TOKYO_NIGHT: Theme = Theme {
     dir: Color(39),
@@ -439,42 +419,28 @@ pub const SOLARIZED_DARK: Theme = Theme {
     burn: Color(167),
 };
 
-/// Resolve a theme by name. Unknown names fall back to Tokyo Night.
-#[must_use]
-pub fn get(name: &str) -> Theme {
-    match name {
-        "ayu-mirage" => AYU_MIRAGE,
-        "catppuccin" => CATPPUCCIN,
-        "cobalt2" => COBALT2,
-        "everforest-dark" => EVERFOREST_DARK,
-        "github-dark" => GITHUB_DARK,
-        "gruvbox" => GRUVBOX,
-        "kanagawa-wave" => KANAGAWA_WAVE,
-        "moonfly" => MOONFLY,
-        "night-owl" => NIGHT_OWL,
-        "nord" => NORD,
-        "one-dark" => ONE_DARK,
-        "dracula" => DRACULA,
-        "rose-pine" => ROSE_PINE,
-        "sonokai" => SONOKAI,
-        "solarized-dark" => SOLARIZED_DARK,
-        _ => TOKYO_NIGHT,
-    }
+crate::registry! { Theme, TOKYO_NIGHT,
+    "tokyo-night"     => TOKYO_NIGHT,
+    "ayu-mirage"      => AYU_MIRAGE,
+    "catppuccin"      => CATPPUCCIN,
+    "cobalt2"         => COBALT2,
+    "everforest-dark" => EVERFOREST_DARK,
+    "github-dark"     => GITHUB_DARK,
+    "gruvbox"         => GRUVBOX,
+    "kanagawa-wave"   => KANAGAWA_WAVE,
+    "moonfly"         => MOONFLY,
+    "night-owl"       => NIGHT_OWL,
+    "nord"            => NORD,
+    "one-dark"        => ONE_DARK,
+    "dracula"         => DRACULA,
+    "rose-pine"       => ROSE_PINE,
+    "sonokai"         => SONOKAI,
+    "solarized-dark"  => SOLARIZED_DARK,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[test]
-    fn all_known_names_resolve() {
-        for n in NAMES {
-            let _ = get(n);
-        }
-    }
-    #[test]
-    fn unknown_falls_back_to_tokyo_night() {
-        assert_eq!(get("nope"), TOKYO_NIGHT);
-    }
     #[test]
     fn bar_thresholds_distinct() {
         for n in NAMES {


### PR DESCRIPTION
Name list and lookup were separate. That gap already shipped a bug.

Stacked on #129. Merge in order.

**The bug.** `rounded` sat in `styles::NAMES` with no arm in `get()`, fell through `_ => POWERLINE`, and rendered byte-identical to powerline its whole life. Three copies of one mapping: `NAMES`, the `get()` match, the test table — and the test compared only 3 field per style, too coarse to notice.

**Now.** `registry!` generate `NAMES` and `get()` from one entry list; a name without an arm is a syntax error. Macro also emit `every_name_resolves_to_a_distinct_value` and `an_unknown_name_falls_back`. Mutation-tested: pointed `"rounded" => POWERLINE` to recreate the historical bug, test caught it, reverted.

**PLAIN was ASCII.** Differ in exactly one glyph, now `GlyphSet { worktree: "+", ..ASCII.glyphs }`. Name `plain` stay — removing a user-facing name break existing `config.toml`, that a product call not a refactor.

**Needed `PartialEq, Eq` on `Style`/`GlyphSet`** — their absence is why the old test compared field by field and missed `rounded`. Both `Copy` value type, no behaviour attached.

−45 line.

- [x] render matrix **byte-identical**, `claudebar list` output identical
- [x] `cargo test` (285), `clippy -D warnings`, `cargo doc -D warnings`, `fmt --check`, `--no-default-features` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
