### PR TITLE
chore: check rustdoc in CI, dedupe tui display order

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Clippy (render-only, no TUI)
         run: cargo clippy --locked --no-default-features -- -D warnings
 
+      - name: Docs
+        run: cargo doc --locked --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
+
       - name: Test
         run: cargo test --locked --all-features
         env:

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -179,39 +179,31 @@ impl App {
         }
     }
 
+    /// Segment rows as the right panel lists them: enabled ones in
+    /// `config.segments` order, then the rest in `SegmentKind::ALL` order.
+    pub(crate) fn segment_display_order(&self) -> Vec<SegmentKind> {
+        let mut order: Vec<SegmentKind> = self.config.segments.clone();
+        order.extend(
+            SegmentKind::ALL
+                .iter()
+                .copied()
+                .filter(|k| !self.config.segments.contains(k)),
+        );
+        order
+    }
+
     /// Toggle the segment under `detail_cursor`; the cursor follows it.
     /// `detail_cursor` indexes into the display order (enabled first, then
     /// disabled in `SegmentKind::ALL` order).
     pub(crate) fn toggle_cursor(&mut self) {
-        // Build display order for segments: enabled in config.segments order, then disabled in ALL order.
-        let display_order: Vec<SegmentKind> = {
-            let mut order: Vec<SegmentKind> = self.config.segments.clone();
-            for &kind in &SegmentKind::ALL {
-                if !self.config.segments.contains(&kind) {
-                    order.push(kind);
-                }
-            }
-            order
-        };
-
-        let kind = match display_order.get(self.detail_cursor) {
+        let kind = match self.segment_display_order().get(self.detail_cursor) {
             Some(&k) => k,
             None => return,
         };
 
         toggle_segment(&mut self.config.segments, kind);
 
-        // Update detail_cursor to follow the toggled segment in new display order.
-        let new_display_order: Vec<SegmentKind> = {
-            let mut order: Vec<SegmentKind> = self.config.segments.clone();
-            for &kind in &SegmentKind::ALL {
-                if !self.config.segments.contains(&kind) {
-                    order.push(kind);
-                }
-            }
-            order
-        };
-        if let Some(idx) = new_display_order.iter().position(|&k| k == kind) {
+        if let Some(idx) = self.segment_display_order().iter().position(|&k| k == kind) {
             self.detail_cursor = idx;
         }
     }
@@ -288,17 +280,10 @@ impl App {
             return None;
         }
         match self.menu_cursor {
-            0 => {
-                let mut order: Vec<SegmentKind> = self.config.segments.clone();
-                for &kind in &SegmentKind::ALL {
-                    if !self.config.segments.contains(&kind) {
-                        order.push(kind);
-                    }
-                }
-                order
-                    .get(self.detail_cursor)
-                    .map(|&kind| segment_help(kind))
-            }
+            0 => self
+                .segment_display_order()
+                .get(self.detail_cursor)
+                .map(|&kind| segment_help(kind)),
             3 => {
                 const ORDER: [ThresholdField; 6] = [
                     ThresholdField::Warn,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -348,17 +348,7 @@ fn handle_normal(app: &mut App, key: KeyEvent) {
             app.toggle_cursor();
         }
         KeyCode::Char('m') if app.focused_panel == Panel::Right && app.menu_cursor == 0 => {
-            // Build segment display order to find the kind at detail_cursor.
-            let display_order: Vec<crate::model::SegmentKind> = {
-                let mut order = app.config.segments.clone();
-                for &kind in &crate::model::SegmentKind::ALL {
-                    if !app.config.segments.contains(&kind) {
-                        order.push(kind);
-                    }
-                }
-                order
-            };
-            match display_order.get(app.detail_cursor) {
+            match app.segment_display_order().get(app.detail_cursor) {
                 Some(&kind) if app.config.segments.contains(&kind) => {
                     app.reorder_mode = true;
                 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -259,18 +259,7 @@ fn draw_right_panel(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn build_segment_lines(app: &App, width: u16) -> Vec<Line<'static>> {
-    // Display order: enabled in config.segments order, then disabled in ALL order.
-    let display_order: Vec<crate::model::SegmentKind> = {
-        let mut order: Vec<crate::model::SegmentKind> = app.config.segments.clone();
-        for &kind in &crate::model::SegmentKind::ALL {
-            if !app.config.segments.contains(&kind) {
-                order.push(kind);
-            }
-        }
-        order
-    };
-
-    display_order
+    app.segment_display_order()
         .into_iter()
         .enumerate()
         .map(|(idx, kind)| {


### PR DESCRIPTION
Two follow-up from the audit stack. Both were noted in earlier PR, neither fixed there.

Stacked on #134. Merge in order.

**1. `cargo doc` in CI.** #127 fixed two broken intra-doc link that had been red on main for a long time. Nothing run `cargo doc`, so it rot unnoticed. New step in `rust.yml`:

```yaml
- name: Docs
  run: cargo doc --locked --all-features --no-deps
  env:
    RUSTDOCFLAGS: -D warnings
```

This step cannot land before #127 — on `main` today it fail with `public documentation for refresh_in_background links to private item REFRESH_INTERVAL`. That is why it sit at the top of the stack, not on its own branch.

**2. Segment display order deduped.** #128 flagged "computed in 3 place". Actually **5**: `App::toggle_cursor` twice, `App::context_help`, `ui::build_segment_lines`, `mod::handle_normal` `m` arm. All now call one `App::segment_display_order()`. Net −31 line, no behaviour change — TUI-only, so the render matrix say nothing here; the key-dispatch test from #128 are what cover it.

- [x] `cargo test --all-features` green, 320 test — including the #128 dispatch test that exercise all five call site
- [x] `clippy --all-targets --all-features -D warnings`, `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc` clean

`actionlint` not run locally — no docker daemon in this sandbox. The added step is plain `run:` + `env:`, no `${{ }}` expression; YAML parse verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
