### PR TITLE
docs: link openwiki from readme footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Then remove the `statusLine` entry from `~/.claude/settings.json`, and `~/.confi
 
 ---
 
-**More:** [documentation & live demo](https://micschr0.github.io/claudebar/) · [build from source](https://micschr0.github.io/claudebar/#build) · [contributing](CONTRIBUTING.md) · [contributing a theme](CONTRIBUTING-themes.md) · [changelog](CHANGELOG.md) · [verifying releases](SECURITY.md#verifying-a-release) · [report an issue](https://github.com/micschr0/claudebar/issues)
+**More:** [documentation & live demo](https://micschr0.github.io/claudebar/) · [build from source](https://micschr0.github.io/claudebar/#build) · [contributing](CONTRIBUTING.md) · [contributing a theme](CONTRIBUTING-themes.md) · [internals wiki](openwiki/index.md) · [changelog](CHANGELOG.md) · [verifying releases](SECURITY.md#verifying-a-release) · [report an issue](https://github.com/micschr0/claudebar/issues)
 
 ## License
 


### PR DESCRIPTION
README footer no point to wiki. Now do.

`[internals wiki](openwiki/index.md)` next to contributing links. Dev-facing, so footer — not own section.

Entry point `openwiki/index.md` use relative links, work fine on GitHub. Deeper pages cross-link absolute (`/openwiki/...`, 55 place) — those break in blob view. Generated by workflow, not hand-fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbWrScXgqWeCR8vZopYLSH