### PR TITLE
ci: drop unused coverage HTML, add job timeouts

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -24,6 +24,7 @@ jobs:
   publish:
     name: Publish @micschr0/claudebar
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -18,6 +18,7 @@ jobs:
   update:
     name: OpenWiki update
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write       # push the openwiki/update branch
       pull-requests: write  # open or reuse the PR against it

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,6 +21,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read  # explicit — job perms override workflow perms
       pages: write        # required by actions/deploy-pages

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -35,6 +35,7 @@ jobs:
     name: Open release PR
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -133,6 +134,7 @@ jobs:
     name: Push release tag
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,6 +27,7 @@ jobs:
   renovate:
     name: Renovate
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ jobs:
   check:
     name: fmt, clippy, test, build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read      # checkout requires contents:read for actions/checkout
       pull-requests: write # scttnlsn/covrs posts PR comments and annotation
@@ -86,9 +87,6 @@ jobs:
       - name: Generate coverage data (lcov)
         run: cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
 
-      - name: Generate coverage HTML
-        run: cargo llvm-cov --locked --all-features --html --output-dir target/llvm-cov/html
-
       - name: Coverage PR comment
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: scttnlsn/covrs@0a048b99b9b4b8aaa5d006d60caaf55c8a13c11d # v0.3.2
@@ -96,20 +94,13 @@ jobs:
           coverage-files: lcov.info
           annotate: true
 
-      - name: Upload HTML coverage report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: coverage-html
-          path: target/llvm-cov/html/
-          retention-days: 7
-
       - name: dist workflow drift check
         run: dist generate --check
 
   build-matrix:
     name: build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,6 +17,7 @@ jobs:
   shellcheck:
     name: ShellCheck
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -29,6 +30,7 @@ jobs:
   ruff:
     name: Ruff
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -42,6 +44,7 @@ jobs:
   actionlint:
     name: actionlint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       # Bundles shellcheck + pyflakes, so `run:` blocks get linted too.
       # `--user root`: the image runs as `guest`, which cannot write the workspace.
@@ -61,6 +64,7 @@ jobs:
   bats:
     name: Bats
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -73,6 +77,7 @@ jobs:
   semgrep:
     name: Semgrep
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: semgrep/semgrep:1.176.1@sha256:34ab619bf1391a24bfda3f05debd0d8a6ce3093c2d5f9d39cfc00f83c1397823
     steps:
@@ -85,6 +90,7 @@ jobs:
   cargo-audit:
     name: cargo-audit
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -97,6 +103,7 @@ jobs:
   gitleaks:
     name: gitleaks
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -113,6 +120,7 @@ jobs:
   zizmor:
     name: zizmor
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:

--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         target: [x86_64-unknown-linux-musl, aarch64-unknown-linux-musl]
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -76,6 +77,7 @@ jobs:
       matrix:
         os: [macos-15-intel, macos-15]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Changes

1. **Drop unused HTML coverage** (`rust.yml`): `cargo llvm-cov --html` ran the entire instrumented test suite a second time and uploaded an artifact (7d retention) that nothing consumes. The lcov path for the covrs PR comment stays. Saves ~30-40% of the most expensive block in the `check` job.

2. **Add `timeout-minutes: 30` to every job** in the 8 hand-written workflows (rust, security, release-prep, verify-install, pages, renovate, openwiki-update, npm-release). A hung job now stops after 30 min instead of holding a runner for up to 6 h.

Note: `release.yml` is intentionally untouched — it is generated by `cargo dist generate` and hand edits would be lost on the next regen (and flagged by the `dist generate --check` drift gate).

## Verification

- Local zizmor (pedantic, online): 0 findings on the branch.
- 18/18 jobs have timeouts (grep-verified).