### PR TITLE
fix(release): complete stable changelog rollup, dedup guard, install block

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -99,13 +99,20 @@ jobs:
           # For a stable release, roll up every commit since the last stable tag
           # (not just since the last beta) so intermediate betas aren't dropped.
           if [[ "$VERSION" != *-beta.* ]]; then
-            last_stable="$(git tag -l | grep -vE -- '-beta\.' | sort -V | tail -1)"
+            last_stable="$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)"
             range="${last_stable:+$last_stable..}"
           else
             range=""
           fi
           if [[ -n "$range" ]]; then
-            git-cliff "$range" --tag "$VERSION" --strip all > "$section"
+            # Stable rollup: exclude beta tags so commits shipped in
+            # intermediate betas land in this release's section. dist only
+            # shows the `## [<version>]` section on the release page — with
+            # the default pattern those commits would sit under a beta
+            # heading and the page would list just the post-beta delta.
+            cfg="$RUNNER_TEMP/cliff-stable.toml"
+            sed 's/^tag_pattern = .*/tag_pattern = "[0-9]+\\\\.[0-9]+\\\\.[0-9]+$"/' cliff.toml > "$cfg"
+            git-cliff -c "$cfg" "$range" --tag "$VERSION" --strip all > "$section"
           else
             git-cliff --unreleased --tag "$VERSION" --strip all > "$section"
           fi
@@ -113,6 +120,21 @@ jobs:
             || { echo "::error::git-cliff produced no entries — nothing to release"; exit 1; }
           grep -q '<!-- next-release -->' CHANGELOG.md
           sed -i "/<!-- next-release -->/r $section" CHANGELOG.md
+          # Defensive: if the range base is ever wrong, git-cliff re-emits
+          # sections for stable tags inside the range; the stale repeats
+          # would make parse-changelog (used by cargo-dist for the release
+          # body) abort on duplicate version headings — silently dropping
+          # the release notes. Keep the first (newest) copy, drop the rest.
+          # Only version-shaped headings key the dedup, so prose, the
+          # compound `## [x] / [y]` heading, and fenced blocks never match.
+          awk '
+            /^## \[[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+)?\]/ {
+              ver = $0; sub(/\].*/, "", ver)
+              dup = (ver in seen)
+              seen[ver] = 1
+            }
+            !dup { print }
+          ' CHANGELOG.md > CHANGELOG.md.next && mv CHANGELOG.md.next CHANGELOG.md
 
       - name: Commit and open PR
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,6 +277,21 @@ jobs:
         run: |
           # Write and read notes from a file to avoid quoting breaking things
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          cat >> $RUNNER_TEMP/notes.txt <<'EOF'
+
+          ## More install methods
+
+          ```sh
+          curl -fsSL https://raw.githubusercontent.com/micschr0/claudebar/main/install.sh | bash  # verifies SHA256
+          mise use -g github:micschr0/claudebar                                                   # verifies SHA256 + provenance
+          pnpm add -g @micschr0/claudebar                                                         # npm-registry package
+          ```
+
+          Beta channel: `brew install micschr0/tap/claudebar-beta`. Details: README.
+
+          EOF
+
+          # ⚠️ Reapply after 'dist generate'.
 
           gh release create "$RELEASE_TAG" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
       - name: Prune older prereleases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,19 @@ see `RELEASING.md` for the release ritual.
 
 <!-- next-release -->
 
-## [2026.8.27](https://github.com/micschr0/claudebar/compare/2026.8.26-beta.1...2026.8.27)
-
-### Fixed
-- Changelog since last stable tag (#113)
-- Move CLAUDEBAR_CHANNEL to bash side of pipe (#111)
-
-## [2026.8.26-beta.1](https://github.com/micschr0/claudebar/compare/2026.7.21...2026.8.26-beta.1)
+## [2026.8.27](https://github.com/micschr0/claudebar/compare/2026.7.21...2026.8.27)
 
 ### Added
 - Add manual release check command (#96)
 - Publish claudebar via npm platform packages (#97)
 
 ### Fixed
+- Changelog since last stable tag (#113)
 - Correct permission input name (#65)
 - Grant statuses permission (#77)
 - Grant workflows permission, fix dead lockfile schedule (#76)
 - Hide style-list glyphs for styles with icons off (#109)
+- Move CLAUDEBAR_CHANNEL to bash side of pipe (#111)
 - Strip cargo-dist target prefix on extract (#105)
 - Strip cargo-dist target prefix when extracting release assets (#100)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -90,8 +90,21 @@ the `## [<version>]` section as the GitHub Release body.
    marker, then amend it into the release commit:
 
    ```bash
+   # beta release (delta since the last tag):
    git-cliff --unreleased --tag 2026.6.25 --strip all > /tmp/section.md
+
+   # stable release with betas in between — roll up everything since the last
+   # stable tag. Beta tags are excluded via a patched tag_pattern, otherwise
+   # those commits would sit under beta headings and dist (which shows only
+   # the `## [<version>]` section on the release page) would list just the
+   # post-beta delta.
+   sed 's/^tag_pattern = .*/tag_pattern = "[0-9]+\\\\.[0-9]+\\\\.[0-9]+$"/' cliff.toml > /tmp/cliff-stable.toml
+   git-cliff -c /tmp/cliff-stable.toml <last-stable>.. --tag 2026.6.25 --strip all > /tmp/section.md
+
    sed -i '/<!-- next-release -->/r /tmp/section.md' CHANGELOG.md
+   # drop duplicate version headings the insert may have created (keep first)
+   awk '/^## \[[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+)?\]/{v=$0;sub(/\].*/,"",v);d=(v in s);s[v]=1}!d' \
+     CHANGELOG.md > /tmp/cl.md && mv /tmp/cl.md CHANGELOG.md
    git add CHANGELOG.md && git commit --amend --no-edit
    ```
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -2,7 +2,9 @@
 #
 # Used by `.github/workflows/release-prep.yml`, which runs
 #
-#   git-cliff --unreleased --tag <calver> --strip all > section.md
+#   beta:              git-cliff --unreleased --tag <calver> --strip all > section.md
+#   stable after beta: git-cliff -c <cfg, tag_pattern stable-only> <last-stable>.. --tag <calver> ...
+#
 #   sed -i '/<!-- next-release -->/r section.md' CHANGELOG.md
 #
 # to splice one new section into CHANGELOG.md below the `<!-- next-release -->`


### PR DESCRIPTION
## Root cause

`release-prep.yml` grouped the stable changelog section by tags: the `## [2026.8.27]` section only carried the post-beta delta, and the rollup since the last stable tag re-emitted a `## [2026.8.26-beta.1]` section that already existed. `parse-changelog` 0.6.16 (used by cargo-dist for the release body) hard-errors on duplicate version headings; dist swallows the error and publishes the release **without notes** (verified: 2026.8.27 page had none).

## Changes

- **release-prep.yml**: stable rollup runs git-cliff with a temp config whose `tag_pattern` matches stable CalVer tags only, so intermediate-beta commits land in the stable section; `last_stable` now filters to CalVer-shaped tags (a local `backup/*` tag hijacked `sort -V` before); keep-first dedup of version-shaped headings after the insert
- **release.yml**: append a static "More install methods" block (install.sh / mise / pnpm / beta) to the release body, with the usual `⚠️ Reapply after 'dist generate'` marker
- **CHANGELOG.md**: dedup 2026.8.26-beta.1, complete 2026.8.27 rollup (compare base 2026.7.21)
- **RELEASING.md / cliff.toml**: document both git-cliff variants

## Verification

- workflow step extracted from YAML and executed at the pre-8.27 state: exactly one heading per version, complete rollup
- `dist plan` with the fixed CHANGELOG emits `## Release Notes` (matches the live page)
- parse-changelog probe parses, `get("2026.8.27")` returns full notes
- adversarial review pass: 2 high findings (stray-tag range hijack, loose dedup matcher) fixed, unit-checked

The six existing release pages without notes (2026.6.24 … 2026.7.21) were repaired retroactively via `gh release edit` — not part of this diff.